### PR TITLE
feat: added attach command

### DIFF
--- a/src/jenesis/cli.py
+++ b/src/jenesis/cli.py
@@ -7,6 +7,7 @@ from jenesis.cmd.alpha import add_alpha_command
 from jenesis.cmd.compile import add_compile_command
 from jenesis.cmd.init import add_init_command
 from jenesis.cmd.new import add_new_command
+from jenesis.cmd.attach import add_attach_command
 
 
 def _parse_commandline() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
@@ -18,6 +19,7 @@ def _parse_commandline() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
     add_new_command(subparsers)
     add_compile_command(subparsers)
     add_add_command(subparsers)
+    add_attach_command(subparsers)
 
     return parser, parser.parse_args()
 

--- a/src/jenesis/cmd/add/__init__.py
+++ b/src/jenesis/cmd/add/__init__.py
@@ -4,11 +4,18 @@ from jenesis.cmd.add.contract import run_add_contract
 
 
 def add_add_command(parser):
-    add_cmd = parser.add_parser('add')
+    add_cmd = parser.add_parser("add")
     subparsers = add_cmd.add_subparsers()
 
-    add_contract_cmd = subparsers.add_parser('contract', help='Contract service templates')
-    add_contract_cmd.add_argument('template', help='The name of the template to use')
-    add_contract_cmd.add_argument('name', help='The name of contract to create')
-    add_contract_cmd.add_argument('-b', '--branch', help='The name of the branch that should be used')
+    add_contract_cmd = subparsers.add_parser(
+        "contract", help="Contract service templates"
+    )
+    add_contract_cmd.add_argument("template", help="The name of the template to use")
+    add_contract_cmd.add_argument("name", help="The name of contract to create")
+    add_contract_cmd.add_argument(
+        "-p", "--profile", default="testing", help="The profile to deploy"
+    )
+    add_contract_cmd.add_argument(
+        "-b", "--branch", help="The name of the branch that should be used"
+    )
     add_contract_cmd.set_defaults(handler=run_add_contract)

--- a/src/jenesis/cmd/add/contract.py
+++ b/src/jenesis/cmd/add/contract.py
@@ -1,11 +1,12 @@
 import argparse
 import os
-from tempfile import mkdtemp
 import shutil
 import subprocess
+from tempfile import mkdtemp
+
 from jenesis.config import Config
 
-TEMPLATE_GIT_URL = 'git@github.com:fetchai/jenesis-templates.git'
+TEMPLATE_GIT_URL = "git@github.com:fetchai/jenesis-templates.git"
 
 
 def run_add_contract(args: argparse.Namespace):
@@ -14,12 +15,18 @@ def run_add_contract(args: argparse.Namespace):
     branch = args.branch
 
     project_root = os.path.abspath(os.getcwd())
-    contract_root = os.path.join(project_root, 'contracts', name)
+    contract_root = os.path.join(project_root, "contracts", name)
 
     # check that we are actually running the command from the project root
-    if not os.path.exists(os.path.join(project_root, 'jenesis.toml')):
-        print('Please run command from project root')
+    if not os.path.exists(os.path.join(project_root, "jenesis.toml")):
+        print("Please run command from project root")
         return False
+
+    cfg = Config.load(project_root)
+
+    if args.profile not in cfg.profiles:
+        print(f'Invalid profile name. Expected one of {",".join(cfg.profiles.keys())}')
+        return 1
 
     # check to see if the contract already exists
     if os.path.exists(contract_root):
@@ -27,26 +34,28 @@ def run_add_contract(args: argparse.Namespace):
         return False
 
     # create the temporary clone folder
-    temp_clone_path = mkdtemp(prefix='jenesis-', suffix='-tmpl')
+    temp_clone_path = mkdtemp(prefix="jenesis-", suffix="-tmpl")
 
     # clone the templates folder out in the temporary file
-    print('Downloading template...')
-    cmd = ['git', 'clone', '--single-branch']
+    print("Downloading template...")
+    cmd = ["git", "clone", "--single-branch"]
     if branch is not None:
-        cmd += ['--branch', branch]
-    cmd += [TEMPLATE_GIT_URL, '.']
-    with open(os.devnull, 'w', encoding='utf8') as null_file:
-        subprocess.check_call(cmd, stdout=null_file, stderr=subprocess.STDOUT, cwd=temp_clone_path)
+        cmd += ["--branch", branch]
+    cmd += [TEMPLATE_GIT_URL, "."]
+    with open(os.devnull, "w", encoding="utf8") as null_file:
+        subprocess.check_call(
+            cmd, stdout=null_file, stderr=subprocess.STDOUT, cwd=temp_clone_path
+        )
 
     # find the target contract
-    contract_template_path = os.path.join(temp_clone_path, 'contracts', template)
+    contract_template_path = os.path.join(temp_clone_path, "contracts", template)
     if not os.path.isdir(contract_template_path):
-        print(f'Unknown template {template}')
+        print(f"Unknown template {template}")
         return False
-    print('Downloading template...complete')
+    print("Downloading template...complete")
 
     # process all the files as part of the template
-    print('Rendering template...')
+    print("Rendering template...")
     for root, _, files in os.walk(contract_template_path):
         for filename in files:
             file_path = os.path.join(root, filename)
@@ -54,19 +63,19 @@ def run_add_contract(args: argparse.Namespace):
 
             output_filepath = os.path.join(contract_root, rel_path)
             os.makedirs(os.path.dirname(output_filepath), exist_ok=True)
-            with open(file_path, 'r', encoding='utf8') as input_file:
-                with open(output_filepath, 'w', encoding='utf8') as output_file:
+            with open(file_path, "r", encoding="utf8") as input_file:
+                with open(output_filepath, "w", encoding="utf8") as output_file:
                     contents = input_file.read()
 
                     # replace the templating parameters here
-                    contents = contents.replace('<<NAME>>', name)
+                    contents = contents.replace("<<NAME>>", name)
 
                     output_file.write(contents)
-    print('Rendering template...complete')
+    print("Rendering template...complete")
 
     # clean up the temporary folder
     shutil.rmtree(temp_clone_path)
 
-    Config.create_project(os.getcwd())
+    Config.create_project(os.getcwd(), args.profile)
 
     return True

--- a/src/jenesis/cmd/add/contract.py
+++ b/src/jenesis/cmd/add/contract.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import subprocess
 from tempfile import mkdtemp
+from jenesis.contracts.detect import detect_contracts
 
 from jenesis.config import Config
 
@@ -77,6 +78,18 @@ def run_add_contract(args: argparse.Namespace):
     # clean up the temporary folder
     shutil.rmtree(temp_clone_path)
 
-    Config.create_project(os.getcwd(), args.profile)
+    contracts = detect_contracts(project_root)
+
+    selected_contract = ""
+    for contract in contracts:
+        if contract.name == name:
+            selected_contract = contract
+            continue
+
+    if selected_contract == "":
+        print('Contract not found in project')
+        return
+
+    Config.update_project(os.getcwd(), args.profile, selected_contract)
 
     return True

--- a/src/jenesis/cmd/add/contract.py
+++ b/src/jenesis/cmd/add/contract.py
@@ -19,6 +19,7 @@ def run_add_contract(args: argparse.Namespace):
 
     # check that we are actually running the command from the project root
     if not os.path.exists(os.path.join(project_root, "jenesis.toml")):
+        # pylint: disable=all
         print("Please run command from project root")
         return False
 

--- a/src/jenesis/cmd/alpha/deploy.py
+++ b/src/jenesis/cmd/alpha/deploy.py
@@ -11,6 +11,7 @@ def run(args: argparse.Namespace):
 
     # check that we are actually running the command from the project root
     if not os.path.exists(os.path.join(project_path, "jenesis.toml")):
+        # pylint: disable=all
         print("Please run command from project root")
         return 1
 

--- a/src/jenesis/cmd/alpha/deploy.py
+++ b/src/jenesis/cmd/alpha/deploy.py
@@ -6,13 +6,21 @@ from jenesis.contracts.deploy import deploy_contracts
 
 
 def run(args: argparse.Namespace):
-    cfg = Config.load(os.getcwd())
+
+    project_path = os.getcwd()
+
+    # check that we are actually running the command from the project root
+    if not os.path.exists(os.path.join(project_path, "jenesis.toml")):
+        print("Please run command from project root")
+        return 1
+
+    cfg = Config.load(project_path)
 
     if args.profile not in cfg.profiles:
         print(f'Invalid profile name. Expected one of {",".join(cfg.profiles.keys())}')
         return 1
 
-    deploy_contracts(cfg, args.profile, os.getcwd(), args.key)
+    deploy_contracts(cfg, args.profile, project_path, args.key)
     return 0
 
 
@@ -21,5 +29,5 @@ def add_deploy_command(parser):
     deploy_cmd.add_argument(
         "-p", "--profile", default="testing", help="The profile to deploy"
     )
-    deploy_cmd.add_argument("key", nargs='?', metavar="KEY", help="Deployer Key for all contracts")
+    deploy_cmd.add_argument("key", nargs="?", help="Deployer Key for all contracts")
     deploy_cmd.set_defaults(handler=run)

--- a/src/jenesis/cmd/alpha/run.py
+++ b/src/jenesis/cmd/alpha/run.py
@@ -1,16 +1,26 @@
 import argparse
+import os
 
 from .shell import load_config
 
 
 def run(args: argparse.Namespace):
+    project_path = os.getcwd()
+
+    # check that we are actually running the command from the project root
+    if not os.path.exists(os.path.join(project_path, "jenesis.toml")):
+        print("Please run command from project root")
+        return
+
     shell_globals = load_config(args)
-    with open(args.script_path, encoding='utf-8') as script:
+    with open(args.script_path, encoding="utf-8") as script:
         exec(script.read(), shell_globals)
 
 
 def add_run_command(parser):
-    run_cmd = parser.add_parser('run')
-    run_cmd.add_argument('-p', '--profile', default='testing', help='The profile to use')
-    run_cmd.add_argument('script_path', help='The path to the script to run')
+    run_cmd = parser.add_parser("run")
+    run_cmd.add_argument(
+        "-p", "--profile", default="testing", help="The profile to use"
+    )
+    run_cmd.add_argument("script_path", help="The path to the script to run")
     run_cmd.set_defaults(handler=run)

--- a/src/jenesis/cmd/alpha/run.py
+++ b/src/jenesis/cmd/alpha/run.py
@@ -9,6 +9,7 @@ def run(args: argparse.Namespace):
 
     # check that we are actually running the command from the project root
     if not os.path.exists(os.path.join(project_path, "jenesis.toml")):
+        # pylint: disable=all
         print("Please run command from project root")
         return
 

--- a/src/jenesis/cmd/alpha/shell.py
+++ b/src/jenesis/cmd/alpha/shell.py
@@ -15,6 +15,7 @@ def load_config(args: argparse.Namespace) -> dict:
 
     # check that we are actually running the command from the project root
     if not os.path.exists(os.path.join(project_path, "jenesis.toml")):
+        # pylint: disable=all
         print("Please run command from project root")
         return 1
 

--- a/src/jenesis/cmd/alpha/shell.py
+++ b/src/jenesis/cmd/alpha/shell.py
@@ -2,12 +2,12 @@ import argparse
 import os
 
 from cosmpy.aerial.client import LedgerClient
+from ptpython import embed
 from jenesis.config import Config
 from jenesis.contracts.detect import detect_contracts
 from jenesis.contracts.monkey import MonkeyContract
 from jenesis.contracts.networks import get_network_config
 from jenesis.contracts.observer import DeploymentUpdater
-from ptpython import embed
 
 
 def load_config(args: argparse.Namespace) -> dict:

--- a/src/jenesis/cmd/attach.py
+++ b/src/jenesis/cmd/attach.py
@@ -27,15 +27,20 @@ def run(args: argparse.Namespace):
     selected_profile = cfg.profiles[args.profile]
     network_cfg = get_network_config(selected_profile.network)
     if network_cfg is None:
-        print("Not network configuration for this profile")
+        print("No network configuration for this profile")
         return
 
     contracts = detect_contracts(project_path)
 
+    selected_contract = ""
     for contract in contracts:
         if contract.name == args.contract:
             selected_contract = contract
             continue
+
+    if selected_contract == "":
+        print('Contract not found in project')
+        return
 
     client = LedgerClient(network_cfg)
 
@@ -43,7 +48,7 @@ def run(args: argparse.Namespace):
     code_id = contract.code_id
     digest = contract.digest.hex()
 
-    Config.create_project(project_path, args.profile)
+    Config.update_project(project_path, args.profile, selected_contract)
     cfg.update_deployment(
         selected_profile.name, args.contract, digest, code_id, args.address
     )

--- a/src/jenesis/cmd/attach.py
+++ b/src/jenesis/cmd/attach.py
@@ -1,0 +1,64 @@
+import argparse
+import os
+
+from cosmpy.aerial.client import LedgerClient
+from jenesis.config import Config
+from jenesis.contracts.detect import detect_contracts
+from jenesis.contracts.monkey import MonkeyContract
+from jenesis.contracts.networks import get_network_config
+
+
+def run(args: argparse.Namespace):
+
+    project_path = os.getcwd()
+
+    # check that we are actually running the command from the project root
+    if not os.path.exists(os.path.join(project_path, "jenesis.toml")):
+        print("Please run command from project root")
+        return
+
+    cfg = Config.load(project_path)
+
+    if args.profile not in cfg.profiles:
+        print(f'Invalid profile name. Expected one of {",".join(cfg.profiles.keys())}')
+        return
+
+    selected_profile = cfg.profiles[args.profile]
+    network_cfg = get_network_config(selected_profile.network)
+    if network_cfg is None:
+        print("Not network configuration for this profile")
+        return
+
+    contracts = detect_contracts(project_path)
+
+    for contract in contracts:
+        if contract.name == args.contract:
+            selected_contract = contract
+            continue
+
+    # selected_contract = [C for C in contracts if C.name == name][0]
+    client = LedgerClient(network_cfg)
+
+    contract = MonkeyContract(selected_contract.binary_path, client, args.address)
+    code_id = contract.code_id
+    digest = contract.digest.hex()
+
+    Config.create_project(project_path, args.profile)
+    cfg.update_deployment(
+        selected_profile.name, args.contract, digest, code_id, args.address
+    )
+    # cfg.load(project_path)
+    cfg.save(project_path)
+
+
+def add_attach_command(parser):
+    attach_cmd = parser.add_parser("attach")
+    attach_cmd.add_argument("contract", help="Contract name")
+    attach_cmd.add_argument("address", help="Contract address")
+    attach_cmd.add_argument(
+        "-p",
+        "--profile",
+        default="testing",
+        help="Profile where the contract will be attached",
+    )
+    attach_cmd.set_defaults(handler=run)

--- a/src/jenesis/cmd/attach.py
+++ b/src/jenesis/cmd/attach.py
@@ -14,6 +14,7 @@ def run(args: argparse.Namespace):
 
     # check that we are actually running the command from the project root
     if not os.path.exists(os.path.join(project_path, "jenesis.toml")):
+        # pylint: disable=all
         print("Please run command from project root")
         return
 
@@ -36,7 +37,6 @@ def run(args: argparse.Namespace):
             selected_contract = contract
             continue
 
-    # selected_contract = [C for C in contracts if C.name == name][0]
     client = LedgerClient(network_cfg)
 
     contract = MonkeyContract(selected_contract.binary_path, client, args.address)
@@ -47,7 +47,6 @@ def run(args: argparse.Namespace):
     cfg.update_deployment(
         selected_profile.name, args.contract, digest, code_id, args.address
     )
-    # cfg.load(project_path)
     cfg.save(project_path)
 
 

--- a/src/jenesis/cmd/compile.py
+++ b/src/jenesis/cmd/compile.py
@@ -2,21 +2,28 @@ import argparse
 import os
 
 from blessings import Terminal
-
 from jenesis.contracts.build import build_contracts, build_workspace
 from jenesis.contracts.detect import detect_contracts, is_workspace
 
 
 def run(args: argparse.Namespace):
-    term = Terminal()
 
-    contracts = detect_contracts(os.getcwd())
-    if contracts is None or len(contracts) == 0:
-        print(term.red('Unable to detect any contracts'))
+    project_path = os.getcwd()
+
+    # check that we are actually running the command from the project root
+    if not os.path.exists(os.path.join(project_path, "jenesis.toml")):
+        print("Please run command from project root")
         return 1
 
-    if is_workspace(os.getcwd()):
-        build_workspace(os.getcwd(), contracts)
+    term = Terminal()
+
+    contracts = detect_contracts(project_path)
+    if contracts is None or len(contracts) == 0:
+        print(term.red("Unable to detect any contracts"))
+        return 1
+
+    if is_workspace(project_path):
+        build_workspace(project_path, contracts)
         return 0
 
     # build the contracts
@@ -25,6 +32,11 @@ def run(args: argparse.Namespace):
 
 
 def add_compile_command(parser):
-    compile_cmd = parser.add_parser('compile')
-    compile_cmd.add_argument('-p', dest='batch_size', type=int, help='The limit of the number of tasks to do in parallel')
+    compile_cmd = parser.add_parser("compile")
+    compile_cmd.add_argument(
+        "-p",
+        dest="batch_size",
+        type=int,
+        help="The limit of the number of tasks to do in parallel",
+    )
     compile_cmd.set_defaults(handler=run)

--- a/src/jenesis/cmd/init.py
+++ b/src/jenesis/cmd/init.py
@@ -4,10 +4,15 @@ import os
 from jenesis.config import Config
 
 
-def run(_args: argparse.Namespace):
-    Config.create_project(os.getcwd())
+def run(args: argparse.Namespace):
+
+    project_path = os.getcwd()
+    Config.create_project(project_path, args.profile)
 
 
 def add_init_command(parser):
     init_cmd = parser.add_parser("init")
+    init_cmd.add_argument(
+        "-p", "--profile", default="testing", help="The profile to initialize"
+    )
     init_cmd.set_defaults(handler=run)

--- a/src/jenesis/cmd/new.py
+++ b/src/jenesis/cmd/new.py
@@ -4,10 +4,13 @@ from jenesis.config import Config
 
 
 def run(args: argparse.Namespace):
-    Config.create_project(args.project)
+    Config.create_project(args.project, args.profile)
 
 
 def add_new_command(parser):
     new_cmd = parser.add_parser("new")
-    new_cmd.add_argument("project", metavar="NAME", help="Project name")
+    new_cmd.add_argument("project", help="Project name")
+    new_cmd.add_argument(
+        "-p", "--profile", default="testing", help="The profile to create"
+    )
     new_cmd.set_defaults(handler=run)

--- a/src/jenesis/config/__init__.py
+++ b/src/jenesis/config/__init__.py
@@ -241,7 +241,7 @@ class Config:
             toml.dump(contents, lock_file)
 
     @staticmethod
-    def create_project(path: str):
+    def create_project(path: str, profile:str):
         user_name = subprocess.getoutput("git config user.name")
         user_email = subprocess.getoutput("git config user.email")
         authors = [f"{user_name} <{user_email}>"]
@@ -259,7 +259,7 @@ class Config:
         ) for contract in contracts}
 
         profiles = {
-            "testing": {
+            profile: {
                 "network": "fetchai-testnet",
                 "contracts": {name: vars(cfg) for (name, cfg) in contract_cfgs.items()},
             }

--- a/src/jenesis/config/__init__.py
+++ b/src/jenesis/config/__init__.py
@@ -286,3 +286,23 @@ class Config:
 
             with open(git_keep_path, "a", encoding="utf-8"):
                 pass
+
+    @staticmethod
+    def update_project(path: str, profile:str, contract: Contract):
+
+        # take the project name directly from the base name of the project
+        project_root = os.path.abspath(path)
+
+        contract_cfgs = {contract.name: Deployment(contract,
+            "fetchai-testnet", "", {arg: "" for arg in contract.init_args()},
+            None, None, None, None)}
+
+        data = toml.load("jenesis.toml") 
+
+        for (name, cfg) in contract_cfgs.items():
+            data["profile"][profile]["contracts"][name] = vars(cfg)
+
+        project_configuration_file = os.path.join(project_root, "jenesis.toml")
+
+        with open(project_configuration_file, "w") as toml_file:
+            toml.dump(data, toml_file)

--- a/src/jenesis/config/__init__.py
+++ b/src/jenesis/config/__init__.py
@@ -293,14 +293,13 @@ class Config:
         # take the project name directly from the base name of the project
         project_root = os.path.abspath(path)
 
-        contract_cfgs = {contract.name: Deployment(contract,
+        contract_cfg = Deployment(contract,
             "fetchai-testnet", "", {arg: "" for arg in contract.init_args()},
-            None, None, None, None)}
+            None, None, None, None)
 
         data = toml.load("jenesis.toml")
 
-        for (name, cfg) in contract_cfgs.items():
-            data["profile"][profile]["contracts"][name] = vars(cfg)
+        data["profile"][profile]["contracts"][contract.name] = vars(contract_cfg)
 
         project_configuration_file = os.path.join(project_root, "jenesis.toml")
 

--- a/src/jenesis/config/__init__.py
+++ b/src/jenesis/config/__init__.py
@@ -297,12 +297,12 @@ class Config:
             "fetchai-testnet", "", {arg: "" for arg in contract.init_args()},
             None, None, None, None)}
 
-        data = toml.load("jenesis.toml") 
+        data = toml.load("jenesis.toml")
 
         for (name, cfg) in contract_cfgs.items():
             data["profile"][profile]["contracts"][name] = vars(cfg)
 
         project_configuration_file = os.path.join(project_root, "jenesis.toml")
 
-        with open(project_configuration_file, "w") as toml_file:
+        with open(project_configuration_file, "w", encoding="utf-8") as toml_file:
             toml.dump(data, toml_file)

--- a/tests/jenesis/config/test_parsing.py
+++ b/tests/jenesis/config/test_parsing.py
@@ -28,7 +28,7 @@ def test_new_create_project():
 
     project_name = "ProjectX"
     network = "fetchai-testnet"
-    Config.create_project(project_name)
+    Config.create_project(project_name, "testing")
 
     input_file_name = "jenesis.toml"
     path = os.path.join(os.getcwd(), project_name, input_file_name)
@@ -50,7 +50,7 @@ def test_init_create_project():
     """Test project creation when (init) command is selected"""
 
     network = "fetchai-testnet"
-    Config.create_project(os.getcwd())
+    Config.create_project(os.getcwd(), "testing")
 
     input_file_name = "jenesis.toml"
     path = os.path.join(os.getcwd(), input_file_name)


### PR DESCRIPTION
Added attach command that integrate an already deployed contract into the project

How to use it:

1. Copy and paste your project folder under the contract's directory inside your Jenesis project
2. Run jenesis attach <contract_name> <deployed_contract_address> <profile(default testing)>

This will update the jenesis.lock file with the relevant information. 
Now you will be able to interact with this attached contract using shell or run commands