### PR TITLE
feat: add schema validation for contract messages

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -34,7 +34,7 @@ wrapt = [
 name = "attrs"
 version = "22.1.0"
 description = "Classes Without Boilerplate"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.5"
 
@@ -477,6 +477,21 @@ perf = ["ipython"]
 testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
 
 [[package]]
+name = "importlib-resources"
+version = "5.9.0"
+description = "Read resources from Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+docs = ["jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+
+[[package]]
 name = "iniconfig"
 version = "1.1.1"
 description = "iniconfig: brain-dead simple config-ini parsing"
@@ -553,6 +568,24 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "jsonschema"
+version = "4.15.0"
+description = "An implementation of JSON Schema validation for Python"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+attrs = ">=17.4.0"
+importlib-resources = {version = ">=1.4.0", markers = "python_version < \"3.9\""}
+pkgutil-resolve-name = {version = ">=1.3.10", markers = "python_version < \"3.9\""}
+pyrsistent = ">=0.14.0,<0.17.0 || >0.17.0,<0.17.1 || >0.17.1,<0.17.2 || >0.17.2"
+
+[package.extras]
+format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
+format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "uri-template", "webcolors (>=1.11)"]
 
 [[package]]
 name = "keyring"
@@ -730,6 +763,14 @@ description = "Utility library for gitignore style pattern matching of file path
 category = "dev"
 optional = false
 python-versions = ">=3.7"
+
+[[package]]
+name = "pkgutil_resolve_name"
+version = "1.3.10"
+description = "Resolve a name to an object."
+category = "main"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "platformdirs"
@@ -929,6 +970,14 @@ python-versions = ">=3.6.8"
 
 [package.extras]
 diagrams = ["jinja2", "railroad-diagrams"]
+
+[[package]]
+name = "pyrsistent"
+version = "0.18.1"
+description = "Persistent/Functional/Immutable data structures"
+category = "main"
+optional = false
+python-versions = ">=3.7"
 
 [[package]]
 name = "pytest"
@@ -1200,7 +1249,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "0b2fc0eda46ee832a78f75361035616f80fe0be60dcd87e064e4cf8d6e2382de"
+content-hash = "381b0a2c8684279e96d13c84758211dd869680bc08791e1bd17ae8727d97d7aa"
 
 [metadata.files]
 appdirs = [
@@ -1622,6 +1671,10 @@ importlib-metadata = [
     {file = "importlib_metadata-4.12.0-py3-none-any.whl", hash = "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"},
     {file = "importlib_metadata-4.12.0.tar.gz", hash = "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670"},
 ]
+importlib-resources = [
+    {file = "importlib_resources-5.9.0-py3-none-any.whl", hash = "sha256:f78a8df21a79bcc30cfd400bdc38f314333de7c0fb619763f6b9dabab8268bb7"},
+    {file = "importlib_resources-5.9.0.tar.gz", hash = "sha256:5481e97fb45af8dcf2f798952625591c58fe599d0735d86b10f54de086a61681"},
+]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
@@ -1645,6 +1698,10 @@ jeepney = [
 jinja2 = [
     {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
     {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
+]
+jsonschema = [
+    {file = "jsonschema-4.15.0-py3-none-any.whl", hash = "sha256:2df0fab225abb3b41967bb3a46fd37dc74b1536b5296d0b1c2078cd072adf0f7"},
+    {file = "jsonschema-4.15.0.tar.gz", hash = "sha256:21f4979391bdceb044e502fd8e79e738c0cdfbdc8773f9a49b5769461e82fe1e"},
 ]
 keyring = [
     {file = "keyring-23.9.1-py3-none-any.whl", hash = "sha256:3565b9e4ea004c96e158d2d332a49f466733d565bb24157a60fd2e49f41a0fd1"},
@@ -1799,6 +1856,10 @@ parso = [
 pathspec = [
     {file = "pathspec-0.10.1-py3-none-any.whl", hash = "sha256:46846318467efc4556ccfd27816e004270a9eeeeb4d062ce5e6fc7a87c573f93"},
     {file = "pathspec-0.10.1.tar.gz", hash = "sha256:7ace6161b621d31e7902eb6b5ae148d12cfd23f4a249b9ffb6b9fee12084323d"},
+]
+pkgutil_resolve_name = [
+    {file = "pkgutil_resolve_name-1.3.10-py3-none-any.whl", hash = "sha256:ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e"},
+    {file = "pkgutil_resolve_name-1.3.10.tar.gz", hash = "sha256:357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174"},
 ]
 platformdirs = [
     {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
@@ -1986,6 +2047,29 @@ pynacl = [
 pyparsing = [
     {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
     {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
+]
+pyrsistent = [
+    {file = "pyrsistent-0.18.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:df46c854f490f81210870e509818b729db4488e1f30f2a1ce1698b2295a878d1"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d45866ececf4a5fff8742c25722da6d4c9e180daa7b405dc0a2a2790d668c26"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4ed6784ceac462a7d6fcb7e9b663e93b9a6fb373b7f43594f9ff68875788e01e"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-win32.whl", hash = "sha256:e4f3149fd5eb9b285d6bfb54d2e5173f6a116fe19172686797c056672689daf6"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-win_amd64.whl", hash = "sha256:636ce2dc235046ccd3d8c56a7ad54e99d5c1cd0ef07d9ae847306c91d11b5fec"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e92a52c166426efbe0d1ec1332ee9119b6d32fc1f0bbfd55d5c1088070e7fc1b"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7a096646eab884bf8bed965bad63ea327e0d0c38989fc83c5ea7b8a87037bfc"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cdfd2c361b8a8e5d9499b9082b501c452ade8bbf42aef97ea04854f4a3f43b22"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-win32.whl", hash = "sha256:7ec335fc998faa4febe75cc5268a9eac0478b3f681602c1f27befaf2a1abe1d8"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-win_amd64.whl", hash = "sha256:6455fc599df93d1f60e1c5c4fe471499f08d190d57eca040c0ea182301321286"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:fd8da6d0124efa2f67d86fa70c851022f87c98e205f0594e1fae044e7119a5a6"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bfe2388663fd18bd8ce7db2c91c7400bf3e1a9e8bd7d63bf7e77d39051b85ec"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e3e1fcc45199df76053026a51cc59ab2ea3fc7c094c6627e93b7b44cdae2c8c"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-win32.whl", hash = "sha256:b568f35ad53a7b07ed9b1b2bae09eb15cdd671a5ba5d2c66caee40dbf91c68ca"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-win_amd64.whl", hash = "sha256:d1b96547410f76078eaf66d282ddca2e4baae8964364abb4f4dcdde855cd123a"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:f87cc2863ef33c709e237d4b5f4502a62a00fab450c9e020892e8e2ede5847f5"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bc66318fb7ee012071b2792024564973ecc80e9522842eb4e17743604b5e045"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:914474c9f1d93080338ace89cb2acee74f4f666fb0424896fcfb8d86058bf17c"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-win32.whl", hash = "sha256:1b34eedd6812bf4d33814fca1b66005805d3640ce53140ab8bbb1e2651b0d9bc"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-win_amd64.whl", hash = "sha256:e24a828f57e0c337c8d8bb9f6b12f09dfdf0273da25fda9e314f0b684b415a07"},
+    {file = "pyrsistent-0.18.1.tar.gz", hash = "sha256:d4d61f8b993a7255ba714df3aca52700f8125289f84f704cf80916517c46eb96"},
 ]
 pytest = [
     {file = "pytest-7.1.3-py3-none-any.whl", hash = "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ cosmpy = "^0.5.1"
 mkdocs = "^1.3.1"
 mkdocs-material = "^8.3.9"
 keyring = "^23.9.0"
+jsonschema = "^4.15.0"
 
 [tool.poetry.dev-dependencies]
 coverage = "^6.4.4"

--- a/src/jenesis/cmd/alpha/shell.py
+++ b/src/jenesis/cmd/alpha/shell.py
@@ -37,6 +37,8 @@ def load_config(args: argparse.Namespace) -> dict:
         # build the ledger client
         client = LedgerClient(selected_profile.network)
 
+        print(f'Network: {selected_profile.network.name}')
+
         print('Detecting contracts...')
 
         for contract in contracts:

--- a/src/jenesis/cmd/alpha/shell.py
+++ b/src/jenesis/cmd/alpha/shell.py
@@ -58,7 +58,7 @@ def load_config(args: argparse.Namespace) -> dict:
                 address = None
 
             monkey = MonkeyContract(
-                contract.binary_path,
+                contract,
                 client,
                 address=address,
                 code_id=code_id,

--- a/src/jenesis/cmd/attach.py
+++ b/src/jenesis/cmd/attach.py
@@ -42,7 +42,7 @@ def run(args: argparse.Namespace):
 
     client = LedgerClient(selected_profile.network)
 
-    contract = MonkeyContract(selected_contract.binary_path, client, args.address)
+    contract = MonkeyContract(selected_contract, client, args.address)
     code_id = contract.code_id
     digest = contract.digest.hex()
 

--- a/src/jenesis/contracts/__init__.py
+++ b/src/jenesis/contracts/__init__.py
@@ -18,11 +18,26 @@ class Contract:
 
         return _compute_digest(self.binary_path).hex()
 
-    def messages(self) -> dict:
-        return self.schema.keys()
+    def execute_msgs(self) -> dict:
+        return self._extract_msgs('execute_msg')
+
+    def query_msgs(self) -> dict:
+        return self._extract_msgs('query_msg')
 
     def init_args(self) -> dict:
         return self.schema['instantiate_msg']['properties'].keys()
+
+    def _extract_msgs(self, msg_type: str) -> dict:
+        msgs = {}
+        schemas = self.schema[msg_type]['oneOf']
+        for schema in schemas:
+            msg = schema['required'][0]
+            if 'required' in schema['properties'][msg]:
+                args = schema['properties'][msg]['required']
+            else:
+                args = []
+            msgs[msg] = args
+        return msgs
 
     def __repr__(self):
         return self.name

--- a/src/jenesis/contracts/__init__.py
+++ b/src/jenesis/contracts/__init__.py
@@ -29,7 +29,10 @@ class Contract:
 
     def _extract_msgs(self, msg_type: str) -> dict:
         msgs = {}
-        schemas = self.schema[msg_type]['oneOf']
+        if 'oneOf' in self.schema[msg_type]:
+            schemas = self.schema[msg_type]['oneOf']
+        else:
+            schemas = self.schema[msg_type]['anyOf']
         for schema in schemas:
             msg = schema['required'][0]
             if 'required' in schema['properties'][msg]:

--- a/src/jenesis/contracts/deploy.py
+++ b/src/jenesis/contracts/deploy.py
@@ -77,7 +77,7 @@ class DeployContractTask(Task):
 
         def action():
             return MonkeyContract(
-                self._contract.binary_path,
+                self._contract,
                 self._client,
                 code_id=self._config.code_id,
                 address=self._config.address

--- a/src/jenesis/contracts/monkey.py
+++ b/src/jenesis/contracts/monkey.py
@@ -1,13 +1,19 @@
+from jsonschema import validate, ValidationError
 from typing import Optional, Any
 from abc import ABC, abstractmethod
 
 import grpc
 from cosmpy.aerial.client import LedgerClient
 from cosmpy.aerial.contract import LedgerContract, _compute_digest
+from cosmpy.aerial.tx_helpers import SubmittedTx
 from cosmpy.aerial.wallet import Wallet
 from cosmpy.crypto.address import Address
 from cosmpy.protos.cosmwasm.wasm.v1.query_pb2 import QueryCodeRequest
 
+from jenesis.contracts import Contract
+
+EXECUTE_MSG = "execute_msg"
+QUERY_MSG = "query_msg"
 
 class InstantiateArgsError(RuntimeError):
     pass
@@ -26,7 +32,7 @@ class ContractObserver(ABC):
 class MonkeyContract(LedgerContract):
     def __init__(
         self,
-        path: Optional[str],
+        contract: Contract,
         client: LedgerClient,
         address: Optional[Address] = None,
         digest: Optional[bytes] = None,
@@ -35,15 +41,15 @@ class MonkeyContract(LedgerContract):
         init_args: Optional[dict] = None,
     ):
         # pylint: disable=super-init-not-called
-        self._path = path
+        self._contract = contract
         self._client = client
         self._address = address
         self._observer = observer
         self._init_args = init_args
 
         # build the digest
-        if path is not None:
-            self._digest = _compute_digest(self._path)
+        if contract.binary_path is not None:
+            self._digest = _compute_digest(contract.binary_path)
         elif digest is not None:
             self._digest = digest
         else:
@@ -116,6 +122,20 @@ class MonkeyContract(LedgerContract):
             funds=funds
         )
         return address
+
+    def execute(
+        self,
+        args: Any,
+        sender: Wallet,
+        gas_limit: Optional[int] = None,
+        funds: Optional[str] = None,
+    ) -> SubmittedTx:
+        validate(args, self._contract.schema[EXECUTE_MSG])
+        super().execute(args, sender, gas_limit, funds)
+
+    def query(self, args: Any) -> Any:
+        validate(args, self._contract.schema[QUERY_MSG])
+        super().query(args)
 
     def _find_contract_id_by_digest_with_hint(self, code_id_hint: int) -> Optional[int]:
 

--- a/src/jenesis/contracts/monkey.py
+++ b/src/jenesis/contracts/monkey.py
@@ -62,10 +62,6 @@ class MonkeyContract(LedgerContract):
         else:
             self._code_id = self._find_contract_id_by_digest(self._digest)
 
-    @property
-    def path(self) -> Optional[str]:
-        return self._contract.binary_path
-
     def store(
             self,
             sender: Wallet,

--- a/src/jenesis/contracts/monkey.py
+++ b/src/jenesis/contracts/monkey.py
@@ -1,4 +1,3 @@
-from jsonschema import validate, ValidationError
 from typing import Optional, Any
 from abc import ABC, abstractmethod
 
@@ -9,7 +8,7 @@ from cosmpy.aerial.tx_helpers import SubmittedTx
 from cosmpy.aerial.wallet import Wallet
 from cosmpy.crypto.address import Address
 from cosmpy.protos.cosmwasm.wasm.v1.query_pb2 import QueryCodeRequest
-
+from jsonschema import validate
 from jenesis.contracts import Contract
 
 EXECUTE_MSG = "execute_msg"

--- a/src/jenesis/contracts/monkey.py
+++ b/src/jenesis/contracts/monkey.py
@@ -11,6 +11,7 @@ from cosmpy.protos.cosmwasm.wasm.v1.query_pb2 import QueryCodeRequest
 from jsonschema import validate
 from jenesis.contracts import Contract
 
+INSTANTIATE_MSG = "instantiate_msg"
 EXECUTE_MSG = "execute_msg"
 QUERY_MSG = "query_msg"
 
@@ -41,6 +42,7 @@ class MonkeyContract(LedgerContract):
     ):
         # pylint: disable=super-init-not-called
         self._contract = contract
+        self._path = contract.binary_path
         self._client = client
         self._address = address
         self._observer = observer
@@ -59,6 +61,10 @@ class MonkeyContract(LedgerContract):
             self._code_id = self._find_contract_id_by_digest_with_hint(code_id)
         else:
             self._code_id = self._find_contract_id_by_digest(self._digest)
+
+    @property
+    def path(self) -> Optional[str]:
+        return self._contract.binary_path
 
     def store(
             self,
@@ -92,6 +98,7 @@ class MonkeyContract(LedgerContract):
                 raise InstantiateArgsError(
                     'Please provide instantiation arguments either in "args" or in the jenesis.toml configuration for this contract and profile'
                 )
+        validate(args, self._contract.schema[INSTANTIATE_MSG])
         address = super().instantiate(code_id, args, sender, label=label, gas_limit=gas_limit,
                                       admin_address=admin_address, funds=funds)
 


### PR DESCRIPTION
- Validates messages against schema before sending them to the ledger client
- Adds some functions to briefly list the messages and arguments for execute and query messages

I have mixed feelings about this PR since on the surface we don't gain much as these validations are already done on the ledger side. However, having this functionality on the Jenesis side might open up some possibilities for fancier schema-based features in the future (auto-completion, etc.). Let me know what you think!