### PR TITLE
feat: enable sending funds with contract deployment

### DIFF
--- a/src/jenesis/cmd/add/profile.py
+++ b/src/jenesis/cmd/add/profile.py
@@ -35,7 +35,7 @@ def run(args: argparse.Namespace):
 
     contract_cfgs = {contract.name: Deployment(contract,
         args.network, "", {arg: "" for arg in contract.init_args()},
-        None, None, None, None,
+        "", None, None, None, None,
     ) for contract in contracts}
 
 

--- a/src/jenesis/config/__init__.py
+++ b/src/jenesis/config/__init__.py
@@ -115,7 +115,7 @@ class Config:
             deployment = Deployment(
                 contract,
                 profile.network.name,
-                "", None, None, None, None, None, None
+                "", "", None, None, None, None, None
             )
 
         # update the contract if necessary
@@ -271,7 +271,7 @@ class Config:
 
         contract_cfgs = {contract.name: Deployment(contract,
             network_name, "", {arg: "" for arg in contract.init_args()},
-            None, None, None, None, None,
+            "", None, None, None, None,
         ) for contract in contracts}
 
         if network_name == "fetchai-testnet":
@@ -322,7 +322,7 @@ class Config:
 
         contract_cfg = Deployment(contract,
             network_name, "", {arg: "" for arg in contract.init_args()},
-            None, None, None, None, None)
+            "", None, None, None, None)
 
         data = toml.load("jenesis.toml")
         data["profile"][profile]["contracts"][contract.name] = vars(contract_cfg)

--- a/src/jenesis/config/__init__.py
+++ b/src/jenesis/config/__init__.py
@@ -115,7 +115,7 @@ class Config:
             deployment = Deployment(
                 contract,
                 profile.network.name,
-                "", None, None, None, None, None
+                "", None, None, None, None, None, None
             )
 
         # update the contract if necessary
@@ -271,7 +271,7 @@ class Config:
 
         contract_cfgs = {contract.name: Deployment(contract,
             network_name, "", {arg: "" for arg in contract.init_args()},
-            None, None, None, None,
+            None, None, None, None, None,
         ) for contract in contracts}
 
         if network_name == "fetchai-testnet":
@@ -322,7 +322,7 @@ class Config:
 
         contract_cfg = Deployment(contract,
             network_name, "", {arg: "" for arg in contract.init_args()},
-            None, None, None, None)
+            None, None, None, None, None)
 
         data = toml.load("jenesis.toml")
         data["profile"][profile]["contracts"][contract.name] = vars(contract_cfg)

--- a/src/jenesis/config/__init__.py
+++ b/src/jenesis/config/__init__.py
@@ -24,6 +24,7 @@ class Deployment:
     network: str  # internal: the name of the network to deploy to
     deployer_key: str  # config: the name of the key to use for deployment
     init: Any  # config: init parameters for the contract
+    init_funds: Optional[str] # config: funds to be sent with instantiation msg
     checksum: Optional[str]  # lock: the checksum digest to detect configuration changes
     digest: Optional[str]  # lock: the contract of the deployed contract
     address: Optional[Address]  # lock: the address of the deployed contract
@@ -237,6 +238,7 @@ class Config:
             network=str(network),
             init=extract_opt_dict(contract, "init"),
             deployer_key=extract_req_str(contract, "deployer_key"),
+            init_funds=extract_opt_str(contract, "init_funds"),
             digest=extract_opt_str(lock, "digest"),
             address=opt_address(extract_opt_str(lock, "address")),
             code_id=extract_opt_int(lock, "code_id"),

--- a/src/jenesis/contracts/deploy.py
+++ b/src/jenesis/contracts/deploy.py
@@ -104,7 +104,8 @@ class DeployContractTask(Task):
             return self.ledger_contract.deploy(
                 args=self._config.init,
                 sender=self._wallet,
-                admin_address=self._wallet.address()
+                admin_address=self._wallet.address(),
+                funds=self._config.init_funds,
             )
 
         self._future = self._executor.submit(action)


### PR DESCRIPTION
Some contracts require or allow funds to be sent with the instantiation message. This PR exposes this as a new config entry under the profile contract: `init_funds`. Example:
```toml
[profile.local.contracts.oracle_contract]
contract = "oracle_contract"
network = "fetchai-localnode"
deployer_key = "alice"
init_funds = "1atestfet"
```