### PR TITLE
feat: add standard and optimized compile options

### DIFF
--- a/docs/compile-contracts.md
+++ b/docs/compile-contracts.md
@@ -8,4 +8,6 @@ jenesis compile
 ```
 This will compile all packages in your project's contracts directory and output the wasm code under the artifacts directory. If using a cargo workspace, jenesis will automatically detect this and the compiled contracts will appear in the `contracts/artifacts/`. Otherwise, they will go to the `artifacts` directory under the individual contracts.
 
+By default, the contracts are simply compiled and not optimized. For an optimized build, use the flag `--optimize` or `-o`. To force a rebuild, use the flag `--rebuild` or `-r`.
+
 > *Note: ```jenesis compile``` requires that docker is running and configured with permissions for your user.*

--- a/src/jenesis/cmd/compile.py
+++ b/src/jenesis/cmd/compile.py
@@ -24,11 +24,11 @@ def run(args: argparse.Namespace):
 
     if is_workspace(project_path):
         print(term.green("Detected cargo workspace"))
-        build_workspace(project_path, contracts)
+        build_workspace(project_path, contracts, optimize=args.optimize)
         return 0
 
     # build the contracts
-    build_contracts(contracts, batch_size=args.batch_size)
+    build_contracts(contracts, batch_size=args.batch_size, optimize=args.optimize)
     return 0
 
 
@@ -39,5 +39,11 @@ def add_compile_command(parser):
         dest="batch_size",
         type=int,
         help="The limit of the number of tasks to do in parallel",
+    )
+    compile_cmd.add_argument(
+        "-o",
+        "--optimize",
+        action = "store_true",
+        help="Optimize build",
     )
     compile_cmd.set_defaults(handler=run)

--- a/src/jenesis/cmd/compile.py
+++ b/src/jenesis/cmd/compile.py
@@ -24,11 +24,11 @@ def run(args: argparse.Namespace):
 
     if is_workspace(project_path):
         print(term.green("Detected cargo workspace"))
-        build_workspace(project_path, contracts, optimize=args.optimize)
+        build_workspace(project_path, contracts, optimize=args.optimize, rebuild=args.rebuild)
         return 0
 
     # build the contracts
-    build_contracts(contracts, batch_size=args.batch_size, optimize=args.optimize)
+    build_contracts(contracts, batch_size=args.batch_size, optimize=args.optimize,rebuild=args.rebuild)
     return 0
 
 
@@ -45,5 +45,11 @@ def add_compile_command(parser):
         "--optimize",
         action = "store_true",
         help="Optimize build",
+    )
+    compile_cmd.add_argument(
+        "-r",
+        "--rebuild",
+        action = "store_true",
+        help="Force rebuild",
     )
     compile_cmd.set_defaults(handler=run)

--- a/src/jenesis/contracts/build.py
+++ b/src/jenesis/contracts/build.py
@@ -12,7 +12,7 @@ from jenesis.tasks.monitor import run_tasks
 from jenesis.config import Config
 
 ENTRYPOINT_LINES = [
-    "RUSTFLAGS='-C link-arg=-s' cargo wasm",
+    "RUSTFLAGS='-C link-arg=-s' cargo build --release --target wasm32-unknown-unknown",
     "mkdir -p artifacts",
     "mv target/wasm32-unknown-unknown/release/*.wasm artifacts/",
 ]
@@ -328,7 +328,7 @@ def build_workspace(
     """
     Will attempt to build the cargo workspace including all contracts
 
-    :param optimize: Whether to perform and optimized build
+    :param optimize: Whether to perform an optimized build
     :param rebuild: Whether to force a rebuild of the workspace
     :return:
     """

--- a/src/jenesis/contracts/build.py
+++ b/src/jenesis/contracts/build.py
@@ -11,7 +11,7 @@ from jenesis.tasks import Task, TaskStatus
 from jenesis.tasks.monitor import run_tasks
 from jenesis.config import Config
 
-ENTRYPOINT_LINES = [
+DEFAULT_BUILD_STEPS = [
     "RUSTFLAGS='-C link-arg=-s' cargo build --release --target wasm32-unknown-unknown",
     "mkdir -p artifacts",
     "mv target/wasm32-unknown-unknown/release/*.wasm artifacts/",
@@ -117,7 +117,7 @@ class ContractBuildTask(Task):
 
         # start the container
         entrypoint = None if optimize else "/bin/sh"
-        args = None if optimize else ["-c", " && ".join(ENTRYPOINT_LINES)]
+        args = None if optimize else ["-c", " && ".join(DEFAULT_BUILD_STEPS)]
         return client.containers.run(cls.BUILD_CONTAINER, args, mounts=mounts, entrypoint=entrypoint, detach=True)
 
     @staticmethod
@@ -157,7 +157,7 @@ def build_contracts(
 
     :param contracts: The list of contracts to build
     :param batch_size: The max number of builds to do in parallel. If None then will attempt to all in parallel
-    :param optimize: Whether to perform and optimized build
+    :param optimize: Whether to perform an optimized build
     :param rebuild: Whether to force a rebuild of the contracts
     :return:
     """
@@ -280,7 +280,7 @@ class WorkspaceBuildTask(Task):
 
         # start the container
         entrypoint = None if optimize else "/bin/sh"
-        args = None if optimize else ["-c", " && ".join(ENTRYPOINT_LINES)]
+        args = None if optimize else ["-c", " && ".join(DEFAULT_BUILD_STEPS)]
         return client.containers.run(cls.BUILD_CONTAINER, args, mounts=mounts, entrypoint=entrypoint, detach=True)
 
     @staticmethod


### PR DESCRIPTION
- ```jenesis compile``` now uses a standard, non-optimized compile script: ```RUSTFLAGS='-C link-arg=-s' cargo wasm```
- ```jenesis compile -o``` or ```jenesis compile --optimize``` performs an optimized build
- Adds option ```-r``` or ```--rebuild``` to force rebuilding the contracts or workspace
