### PR TITLE
feat: allow multiple deployments of the same contract

### DIFF
--- a/src/jenesis/cmd/add/contract.py
+++ b/src/jenesis/cmd/add/contract.py
@@ -43,7 +43,7 @@ def run_add_contract(args: argparse.Namespace):
     for contract in contracts:
         if contract.name == name:
             selected_contract = contract
-            continue
+            break
 
     if selected_contract == "":
         print("Contract not found in project")

--- a/src/jenesis/cmd/add/contract.py
+++ b/src/jenesis/cmd/add/contract.py
@@ -2,7 +2,6 @@ import argparse
 import os
 
 from jenesis.config import Config
-from jenesis.contracts.detect import detect_contracts
 
 
 def add_contract_command(parser):
@@ -26,7 +25,6 @@ def run_add_contract(args: argparse.Namespace):
 
     # check that we are actually running the command from the project root
     if not os.path.exists(os.path.join(project_root, "jenesis.toml")):
-        # pylint: disable=all
         print("Please run command from project root")
         return False
 
@@ -35,24 +33,12 @@ def run_add_contract(args: argparse.Namespace):
         print(f'Contract "{name}" already exists')
         return False
 
-    Config.add_contract(contract_root, template, name, branch)
-
-    contracts = detect_contracts(project_root)
-
-    selected_contract = ""
-    for contract in contracts:
-        if contract.name == name:
-            selected_contract = contract
-            break
-
-    if selected_contract == "":
-        print("Contract not found in project")
-        return
+    selected_contract = Config.add_contract(project_root, template, name, branch)
 
     cfg = Config.load(project_root)
 
-    for profile in cfg.profiles.keys():
-        network_name = cfg.profiles[profile].network.name
-        Config.update_project(os.getcwd(), profile, network_name, selected_contract)
+    for (profile_name, profile) in cfg.profiles.items():
+        network_name = profile.network.name
+        Config.update_project(os.getcwd(), profile_name, network_name, selected_contract)
 
     return True

--- a/src/jenesis/cmd/attach.py
+++ b/src/jenesis/cmd/attach.py
@@ -28,21 +28,16 @@ def run(args: argparse.Namespace):
 
     selected_profile = cfg.profiles[profile_name]
 
-    contracts = detect_contracts(project_path)
-
-    selected_contract = ""
-    for contract in contracts:
-        if contract.name == args.contract:
-            selected_contract = contract
-            break
-
-    if selected_contract == "":
-        print('Contract not found in project')
+    if args.contract not in selected_profile.deployments:
+        print('Deployment not found in project')
         return 1
+    deployment = selected_profile.deployments[args.contract]
 
     client = LedgerClient(selected_profile.network)
 
-    contract = MonkeyContract(selected_contract, client, args.address)
+    project_contracts = {contract.name: contract for contract in detect_contracts(project_path)}
+
+    contract = MonkeyContract(project_contracts[deployment.contract], client, args.address)
     code_id = contract.code_id
     digest = contract.digest.hex()
 
@@ -50,10 +45,10 @@ def run(args: argparse.Namespace):
 
     network = Network(**data["profile"][profile_name]["network"])
 
-    Config.update_project(project_path, profile_name, network.name, selected_contract)
+    Config.update_project(project_path, profile_name, network.name, project_contracts[deployment.contract])
 
     cfg.update_deployment(
-        selected_profile.name, args.contract, digest, code_id, args.address
+        selected_profile.name, deployment.name, digest, code_id, args.address
     )
     cfg.save(project_path)
     return 0

--- a/src/jenesis/cmd/attach.py
+++ b/src/jenesis/cmd/attach.py
@@ -34,7 +34,7 @@ def run(args: argparse.Namespace):
     for contract in contracts:
         if contract.name == args.contract:
             selected_contract = contract
-            continue
+            break
 
     if selected_contract == "":
         print('Contract not found in project')

--- a/src/jenesis/cmd/deploy.py
+++ b/src/jenesis/cmd/deploy.py
@@ -11,7 +11,6 @@ def run(args: argparse.Namespace):
 
     # check that we are actually running the command from the project root
     if not os.path.exists(os.path.join(project_path, "jenesis.toml")):
-        # pylint: disable=all
         print("Please run command from project root")
         return 1
 
@@ -21,7 +20,7 @@ def run(args: argparse.Namespace):
         print(f'Invalid profile name. Expected one of {",".join(cfg.profiles.keys())}')
         return 1
 
-    deploy_contracts(cfg, project_path, args.key, profile=args.profile)
+    deploy_contracts(cfg, project_path, args.key, profile_name=args.profile)
     return 0
 
 

--- a/src/jenesis/config/__init__.py
+++ b/src/jenesis/config/__init__.py
@@ -118,15 +118,6 @@ class Config:
 
         deployment = profile.deployments.get(deployment_name)
         assert deployment is not None, f"Deployment not found: {deployment_name}"
-        # if deployment is None:
-        #     deployment = Deployment(
-        #         contract,
-        #         profile.network.name,
-        #         "", "", [],None, None, None, None, None
-        #     )
-
-        # project_contracts = {contract.name: contract for contract in detect_contracts(os.getcwd())}
-        # contract = project_contracts.get(deployment.contract)
 
         # update the contract if necessary
         if digest is not None:

--- a/src/jenesis/config/extract.py
+++ b/src/jenesis/config/extract.py
@@ -82,5 +82,9 @@ def extract_req_list(data: Any, path: str) -> List[Any]:
     return _required(_extract_type(data, path, list))
 
 
+def extract_opt_list(data: Any, path: str) -> Optional[list]:
+    return _extract_type(data, path, list)
+
+
 def extract_req_str_list(data: Any, path: str) -> List[str]:
     return _required(_extract_list_type(data, path, str))

--- a/src/jenesis/contracts/deploy.py
+++ b/src/jenesis/contracts/deploy.py
@@ -2,7 +2,7 @@ import graphlib as gl
 import os
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as ConcurrentTimeoutError
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Set, Union
 
 from cosmpy.aerial.client import LedgerClient
 from cosmpy.aerial.contract import LedgerContract
@@ -47,7 +47,7 @@ def insert_address(contract_address_names: List[str], deployment: Deployment, pr
     return init_data
 
 
-def load_keys(key_names: set[str]) -> Dict[str, PrivateKey]:
+def load_keys(key_names: Set[str]) -> Dict[str, PrivateKey]:
     keys = {}
     available_key_names = set(query_keychain_items())
     for key_name in key_names:

--- a/src/jenesis/contracts/deploy.py
+++ b/src/jenesis/contracts/deploy.py
@@ -152,16 +152,17 @@ def deploy_contracts(cfg: Config, project_path: str, deployer_key: Optional[str]
     if selected_profile.network.is_local:
         run_local_node(selected_profile.network)
 
-    contracts = detect_contracts(project_path)
+    contracts = {contract.name: contract for contract in detect_contracts(project_path)}
 
     contracts_to_deploy = []  # type: List[Tuple[Contract, Deployment]]
     profile_contracts = selected_profile.contracts
     profile_contract_names = list(profile_contracts.keys())
 
     # determine what tasks to do
-    for contract in contracts:
-        if contract.name in profile_contract_names:
-            profile_contract = selected_profile.deployments.get(contract.name)
+    for (contract_name, profile_contract) in profile_contracts.items():
+        if contract_name in contracts:
+            contract = contracts[profile_contract['contract']]
+            deployment = selected_profile.deployments.get(contract_name)
         else:
             continue
         assert profile_contract is not None

--- a/src/jenesis/contracts/deploy.py
+++ b/src/jenesis/contracts/deploy.py
@@ -160,12 +160,13 @@ def deploy_contracts(cfg: Config, project_path: str, deployer_key: Optional[str]
 
     # determine what tasks to do
     for (contract_name, profile_contract) in profile_contracts.items():
+        contract = contracts[profile_contract['contract']]
         if contract_name in contracts:
             contract = contracts[profile_contract['contract']]
             deployment = selected_profile.deployments.get(contract_name)
         else:
             continue
-        assert profile_contract is not None
+        assert deployment is not None
 
         # ensure that contract has been compiled first
         if not os.path.isfile(contract.binary_path):

--- a/src/jenesis/contracts/observer.py
+++ b/src/jenesis/contracts/observer.py
@@ -5,16 +5,16 @@ from jenesis.contracts.monkey import ContractObserver
 
 
 class DeploymentUpdater(ContractObserver):
-    def __init__(self, cfg: Config, project_path: str, profile: str, contract: str):
+    def __init__(self, cfg: Config, project_path: str, profile: str, deployment_name: str):
         self._cfg = cfg
         self._project_path = str(project_path)
         self._profile = str(profile)
-        self._contract = str(contract)
+        self._deployment_name = str(deployment_name)
 
     def on_code_id_update(self, code_id: int):
-        self._cfg.update_deployment(self._profile, self._contract, None, code_id, None)
+        self._cfg.update_deployment(self._profile, self._deployment_name, None, code_id, None)
         self._cfg.save(self._project_path)
 
     def on_contract_address_update(self, address: Address):
-        self._cfg.update_deployment(self._profile, self._contract, None, None, address)
+        self._cfg.update_deployment(self._profile, self._deployment_name, None, None, address)
         self._cfg.save(self._project_path)

--- a/tests/jenesis/cmd/test_add_contract.py
+++ b/tests/jenesis/cmd/test_add_contract.py
@@ -22,7 +22,7 @@ def test_add_contract():
     project_root = os.path.abspath(os.getcwd())
     contract_root = os.path.join(project_root, "contracts", contract_name)
 
-    Config.add_contract(contract_root, template, contract_name, None)
+    Config.add_contract(project_root, template, contract_name, None)
 
     contracts = detect_contracts(project_root)
     contract = contracts[0]


### PR DESCRIPTION
This is a significant refactor that lets you deploy a contract multiple times and tracks these deployments.

For now, the way to do this is to simply copy a profile contract entry (and its init configuration) and rename the top-level heading. For example:
```toml
[profile.local.contracts.oracle_client_contract]
contract = "oracle_client_contract"
network = "fetchai-localnode"
deployer_key = "james"
init_funds = ""
init_addresses = [ "oracle_contract",]

[profile.local.contracts.oracle_client_contract_1]
contract = "oracle_client_contract"
network = "fetchai-localnode"
deployer_key = "james"
init_funds = ""
init_addresses = [ "oracle_contract",]

[profile.local.contracts.oracle_client_contract.init]
oracle_contract_address = "oracle_contract"

[profile.local.contracts.oracle_client_contract_1.init]
oracle_contract_address = "oracle_contract"
```
and then run `jenesis deploy`.

In the near future we probably want to consider a new command like `jenesis add deployment <contract_name> <deployment_name>`.