### PR TITLE
feat: add query and execute msgs as dynamic methods

### DIFF
--- a/src/jenesis/contracts/__init__.py
+++ b/src/jenesis/contracts/__init__.py
@@ -28,9 +28,6 @@ class Contract:
     def init_args(self) -> dict:
         return self.schema.get('instantiate_msg', {}).get('properties',{}).keys()
 
-    def msg_args(self, msg_type) -> dict:
-        pass
-
     def _extract_msgs(self, msg_type: str) -> dict:
         msgs = {}
         if 'oneOf' in self.schema[msg_type]:

--- a/src/jenesis/contracts/__init__.py
+++ b/src/jenesis/contracts/__init__.py
@@ -28,6 +28,9 @@ class Contract:
     def init_args(self) -> dict:
         return self.schema.get('instantiate_msg', {}).get('properties',{}).keys()
 
+    def msg_args(self, msg_type) -> dict:
+        pass
+
     def _extract_msgs(self, msg_type: str) -> dict:
         msgs = {}
         if 'oneOf' in self.schema[msg_type]:

--- a/src/jenesis/contracts/monkey.py
+++ b/src/jenesis/contracts/monkey.py
@@ -174,7 +174,8 @@ class MonkeyContract(LedgerContract):
             return query
 
         for query_msg in self._contract.query_msgs():
-            setattr(self, query_msg, make_query(query_msg))
+            if getattr(self, query_msg, None) is None:
+                setattr(self, query_msg, make_query(query_msg))
 
     def _add_executions(self):
 
@@ -185,7 +186,8 @@ class MonkeyContract(LedgerContract):
             return execute
 
         for execute_msg in self._contract.execute_msgs():
-            setattr(self, execute_msg, make_execution(execute_msg))
+            if getattr(self, execute_msg, None) is None:
+                setattr(self, execute_msg, make_execution(execute_msg))
 
     def __repr__(self):
         return str(self._address)

--- a/src/jenesis/contracts/monkey.py
+++ b/src/jenesis/contracts/monkey.py
@@ -62,6 +62,11 @@ class MonkeyContract(LedgerContract):
         else:
             self._code_id = self._find_contract_id_by_digest(self._digest)
 
+        # add methods based on schema
+        if contract.schema is not None:
+            self._add_queries()
+            self._add_executions()
+
     def store(
             self,
             sender: Wallet,
@@ -159,6 +164,18 @@ class MonkeyContract(LedgerContract):
                 raise
 
         return self._find_contract_id_by_digest(self._digest)
+
+    def _add_queries(self):
+        for query_msg in self._contract.query_msgs():
+            def query():
+                return 1
+            setattr(self, query_msg, query)
+
+    def _add_executions(self):
+        for execute_msg in self._contract.execute_msgs():
+            def execute():
+                return 1
+            setattr(self, execute_msg, execute)
 
     def __repr__(self):
         return str(self._address)

--- a/src/jenesis/contracts/monkey.py
+++ b/src/jenesis/contracts/monkey.py
@@ -166,16 +166,26 @@ class MonkeyContract(LedgerContract):
         return self._find_contract_id_by_digest(self._digest)
 
     def _add_queries(self):
+
+        def make_query(query_msg):
+            def query(*args, **kwargs):
+                query_args = {query_msg: kwargs}
+                return self.query(query_args, *args)
+            return query
+
         for query_msg in self._contract.query_msgs():
-            def query():
-                return 1
-            setattr(self, query_msg, query)
+            setattr(self, query_msg, make_query(query_msg))
 
     def _add_executions(self):
+
+        def make_execution(execute_msg):
+            def execute(*args, **kwargs):
+                execute_args = {execute_msg: kwargs}
+                return self.execute(execute_args, *args)
+            return execute
+
         for execute_msg in self._contract.execute_msgs():
-            def execute():
-                return 1
-            setattr(self, execute_msg, execute)
+            setattr(self, execute_msg, make_execution(execute_msg))
 
     def __repr__(self):
         return str(self._address)


### PR DESCRIPTION
For example, if `my_contract` has a query msg `{'get_count': {}}`, this is now accessible through the shell as 
```python
my_contract.get_count()
```

Similarly, if it has the execute msg `'reset':{'count': 10}`, this can now be executed with:
```python
my_contract.reset(wallets['alice'], count=10)
```