### PR TITLE
fix: check for msg type in schema

### DIFF
--- a/src/jenesis/contracts/__init__.py
+++ b/src/jenesis/contracts/__init__.py
@@ -30,17 +30,18 @@ class Contract:
 
     def _extract_msgs(self, msg_type: str) -> dict:
         msgs = {}
-        if 'oneOf' in self.schema[msg_type]:
-            schemas = self.schema[msg_type]['oneOf']
-        else:
-            schemas = self.schema[msg_type]['anyOf']
-        for schema in schemas:
-            msg = schema['required'][0]
-            if 'required' in schema['properties'][msg]:
-                args = schema['properties'][msg]['required']
+        if msg_type in self.schema:
+            if 'oneOf' in self.schema[msg_type]:
+                schemas = self.schema[msg_type]['oneOf']
             else:
-                args = []
-            msgs[msg] = args
+                schemas = self.schema[msg_type]['anyOf']
+            for schema in schemas:
+                msg = schema['required'][0]
+                if 'required' in schema['properties'][msg]:
+                    args = schema['properties'][msg]['required']
+                else:
+                    args = []
+                msgs[msg] = args
         return msgs
 
     def __repr__(self):


### PR DESCRIPTION
This fixes a bug where if a contract had no query entry point, Jenesis would fail trying to extract the query messages.