### PR TITLE
feat: better handling of docker containers

### DIFF
--- a/src/jenesis/cmd/deploy.py
+++ b/src/jenesis/cmd/deploy.py
@@ -3,6 +3,7 @@ import os
 
 from jenesis.config import Config
 from jenesis.contracts.deploy import deploy_contracts
+from jenesis.network import network_context
 
 
 def run(args: argparse.Namespace):
@@ -20,7 +21,11 @@ def run(args: argparse.Namespace):
         print(f'Invalid profile name. Expected one of {",".join(cfg.profiles.keys())}')
         return 1
 
-    deploy_contracts(cfg, project_path, args.key, profile_name=args.profile)
+    profile = cfg.profiles[args.profile]
+
+    with network_context(profile.network, cfg.project_name, profile.name):
+        deploy_contracts(cfg, project_path, args.key, profile_name=args.profile)
+
     return 0
 
 

--- a/src/jenesis/cmd/deploy.py
+++ b/src/jenesis/cmd/deploy.py
@@ -21,7 +21,7 @@ def run(args: argparse.Namespace):
         print(f'Invalid profile name. Expected one of {",".join(cfg.profiles.keys())}')
         return 1
 
-    profile = cfg.profiles[args.profile]
+    profile = cfg.profiles[args.profile] or cfg.get_default_profile()
 
     with network_context(profile.network, cfg.project_name, profile.name):
         deploy_contracts(cfg, project_path, args.key, profile_name=args.profile)

--- a/src/jenesis/cmd/deploy.py
+++ b/src/jenesis/cmd/deploy.py
@@ -16,12 +16,9 @@ def run(args: argparse.Namespace):
         return 1
 
     cfg = Config.load(project_path)
-
-    if args.profile is not None and args.profile not in cfg.profiles:
-        print(f'Invalid profile name. Expected one of {",".join(cfg.profiles.keys())}')
+    profile = cfg.get_profile(args.profile)
+    if profile is None:
         return 1
-
-    profile = cfg.profiles[args.profile] or cfg.get_default_profile()
 
     with network_context(profile.network, cfg.project_name, profile.name):
         deploy_contracts(cfg, project_path, args.key, profile_name=args.profile)

--- a/src/jenesis/cmd/run.py
+++ b/src/jenesis/cmd/run.py
@@ -10,7 +10,7 @@ from .shell import get_profile, load_shell_globals
 PROJECT_PATH = os.getcwd()
 
 
-def run(args: argparse.Namespace):    
+def run(args: argparse.Namespace):
     cfg = Config.load(PROJECT_PATH)
     profile: Profile = get_profile(cfg, args)
 

--- a/src/jenesis/cmd/run.py
+++ b/src/jenesis/cmd/run.py
@@ -14,7 +14,7 @@ def run(args: argparse.Namespace):
     cfg = Config.load(PROJECT_PATH)
     profile: Profile = get_profile(cfg, args)
 
-    with network_context(profile.network):
+    with network_context(profile.network, cfg.project_name, profile.name):
         shell_globals = load_shell_globals(cfg, profile)
         with open(args.script_path, encoding="utf-8") as script:
             exec(script.read(), shell_globals)

--- a/src/jenesis/cmd/run.py
+++ b/src/jenesis/cmd/run.py
@@ -1,21 +1,23 @@
 import argparse
 import os
 
-from .shell import load_config
+from jenesis.config import Config, Profile
+from jenesis.network import network_context
+
+from .shell import get_profile, load_shell_globals
 
 
-def run(args: argparse.Namespace):
-    project_path = os.getcwd()
+PROJECT_PATH = os.getcwd()
 
-    # check that we are actually running the command from the project root
-    if not os.path.exists(os.path.join(project_path, "jenesis.toml")):
-        # pylint: disable=all
-        print("Please run command from project root")
-        return
 
-    shell_globals = load_config(args)
-    with open(args.script_path, encoding="utf-8") as script:
-        exec(script.read(), shell_globals)
+def run(args: argparse.Namespace):    
+    cfg = Config.load(PROJECT_PATH)
+    profile: Profile = get_profile(cfg, args)
+
+    with network_context(profile.network):
+        shell_globals = load_shell_globals(cfg, profile)
+        with open(args.script_path, encoding="utf-8") as script:
+            exec(script.read(), shell_globals)
 
 
 def add_run_command(parser):

--- a/src/jenesis/cmd/shell.py
+++ b/src/jenesis/cmd/shell.py
@@ -111,7 +111,7 @@ def run(args: argparse.Namespace):
     profile: Profile = get_profile(cfg, args)
     shell_globals = globals()
 
-    with network_context(profile.network):
+    with network_context(profile.network, cfg.project_name, profile.name):
         shell_globals.update(load_shell_globals(cfg, profile))
         embed(shell_globals, vi_mode=False, history_filename=".shell_history")
 

--- a/src/jenesis/cmd/shell.py
+++ b/src/jenesis/cmd/shell.py
@@ -6,27 +6,24 @@ from cosmpy.aerial.client import LedgerClient
 from cosmpy.aerial.faucet import FaucetApi
 from cosmpy.aerial.wallet import LocalWallet
 from cosmpy.crypto.keypairs import PrivateKey
+from docker.models.containers import Container
 from ptpython import embed
-from jenesis.config import Config
+from jenesis.config import Config, Profile
 from jenesis.contracts.detect import detect_contracts
 from jenesis.contracts.monkey import MonkeyContract
 from jenesis.contracts.observer import DeploymentUpdater
 from jenesis.keyring import query_keychain_items, query_keychain_item
-from jenesis.network import run_local_node
+from jenesis.network import network_context
 
 
-def load_config(args: argparse.Namespace) -> dict:
-    project_path = os.getcwd()
+PROJECT_PATH = os.getcwd()
+
+
+def get_profile(cfg: Config, args: argparse.Namespace) -> Profile:
 
     # check that we are actually running the command from the project root
-    if not os.path.exists(os.path.join(project_path, "jenesis.toml")):
+    if not os.path.exists(os.path.join(PROJECT_PATH, "jenesis.toml")):
         raise RuntimeError("Please run command from project root or create project first")
-
-    cfg = Config.load(project_path)
-    contracts = {contract.name: contract for contract in detect_contracts(project_path)}
-
-    shell_globals = {}
-    contract_instances = {}
 
     if args.profile is not None and args.profile not in cfg.profiles:
         print(f'Invalid profile name. Expected one of {",".join(cfg.profiles.keys())}')
@@ -34,13 +31,19 @@ def load_config(args: argparse.Namespace) -> dict:
 
     profile_name = args.profile or cfg.get_default_profile()
 
-    selected_profile = cfg.profiles.get(profile_name)
+    return cfg.profiles.get(profile_name)
+
+
+def load_shell_globals(cfg: Config, selected_profile: Profile) -> dict:
+
+    shell_globals = {}
+    contract_instances = {}
+
+    contracts = {contract.name: contract for contract in detect_contracts(PROJECT_PATH)}
 
     deployments = selected_profile.deployments
 
     if selected_profile is not None:
-        if selected_profile.network.is_local:
-            run_local_node(selected_profile.network)
 
         # build the ledger client
         client = LedgerClient(selected_profile.network)
@@ -64,8 +67,8 @@ def load_config(args: argparse.Namespace) -> dict:
                 code_id=deployment.code_id,
                 observer=DeploymentUpdater(
                     cfg,
-                    project_path,
-                    profile_name,
+                    PROJECT_PATH,
+                    selected_profile.name,
                     deployment_name,
                 ),
                 init_args=deployment.init,
@@ -94,8 +97,8 @@ def load_config(args: argparse.Namespace) -> dict:
         print("No local keychain found")
 
     shell_globals["cfg"] = cfg
-    shell_globals["project_path"] = project_path
-    shell_globals["profile"] = profile_name
+    shell_globals["project_path"] = PROJECT_PATH
+    shell_globals["profile"] = selected_profile.name
     shell_globals["contracts"] = contracts
     shell_globals["wallets"] = wallets
     for (name, instance) in contract_instances.items():
@@ -105,9 +108,13 @@ def load_config(args: argparse.Namespace) -> dict:
 
 
 def run(args: argparse.Namespace):
-    shell_globals = load_config(args)
-    shell_globals.update(globals())
-    embed(shell_globals, vi_mode=False, history_filename=".shell_history")
+    cfg = Config.load(PROJECT_PATH)
+    profile: Profile = get_profile(cfg, args)
+    shell_globals = globals()
+
+    with network_context(profile.network):
+        shell_globals.update(load_shell_globals(cfg, profile))
+        embed(shell_globals, vi_mode=False, history_filename=".shell_history")
 
 
 def add_shell_command(parser):

--- a/src/jenesis/cmd/shell.py
+++ b/src/jenesis/cmd/shell.py
@@ -6,7 +6,6 @@ from cosmpy.aerial.client import LedgerClient
 from cosmpy.aerial.faucet import FaucetApi
 from cosmpy.aerial.wallet import LocalWallet
 from cosmpy.crypto.keypairs import PrivateKey
-from docker.models.containers import Container
 from ptpython import embed
 from jenesis.config import Config, Profile
 from jenesis.contracts.detect import detect_contracts

--- a/src/jenesis/config/__init__.py
+++ b/src/jenesis/config/__init__.py
@@ -139,7 +139,7 @@ class Config:
         if profile_name is None:
             profile_name = self.get_default_profile()
         else:
-            if profile_name in self.profiles:
+            if profile_name not in self.profiles:
                 print(f'Invalid profile name. Expected one of {",".join(self.profiles.keys())}')
                 return None
         return self.profiles[profile_name]

--- a/src/jenesis/config/__init__.py
+++ b/src/jenesis/config/__init__.py
@@ -136,6 +136,15 @@ class Config:
                 return name
         return self.profiles.keys()[0]
 
+    def get_profile(self, profile_name: Optional[str]) -> Optional[Profile]:
+        if profile_name is None:
+            profile_name = self.get_default_profile()
+        else:
+            if profile_name in self.profiles:
+                print(f'Invalid profile name. Expected one of {",".join(self.profiles.keys())}')
+                return None
+        return self.profiles[profile_name]
+
     @classmethod
     def load(cls, path: str) -> "Config":
         project_file_path = os.path.join(path, "jenesis.toml")

--- a/src/jenesis/contracts/deploy.py
+++ b/src/jenesis/contracts/deploy.py
@@ -15,7 +15,6 @@ from jenesis.contracts.detect import detect_contracts
 from jenesis.contracts.monkey import MonkeyContract
 from jenesis.keyring import (LocalInfo, query_keychain_item,
                              query_keychain_items)
-from jenesis.network import run_local_node
 from jenesis.tasks import Task, TaskStatus
 from jenesis.tasks.monitor import run_tasks
 
@@ -200,9 +199,6 @@ def deploy_contracts(cfg: Config, project_path: str, deployer_key: Optional[str]
         profile_name = cfg.get_default_profile()
 
     profile = cfg.profiles[profile_name]
-
-    if profile.network.is_local:
-        run_local_node(profile.network)
 
     project_contracts = {contract.name: contract for contract in detect_contracts(project_path)}
     deployments = profile.deployments

--- a/src/jenesis/contracts/deploy.py
+++ b/src/jenesis/contracts/deploy.py
@@ -191,6 +191,9 @@ class DeployContractTask(Task):
             self._status = TaskStatus.FAILED
         self._status_text = ''
 
+    def teardown(self):
+        pass
+
 
 def deploy_contracts(cfg: Config, project_path: str, deployer_key: Optional[str], profile_name: Optional[str] = None):
     if profile_name is None:

--- a/src/jenesis/network/__init__.py
+++ b/src/jenesis/network/__init__.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 import os
 import tempfile
 import time
-from typing import Container, Optional, List
+from typing import Optional, List
 
 from docker import from_env
 from docker.errors import DockerException
@@ -184,9 +184,7 @@ def run_local_node(network: Network) -> Optional[Container]:
                 raise RuntimeError('Failed to start local node.')
             print("Stating local node...complete")
             return container
-        else:
-            print("Detected local node already running.")
-            return None
+        print("Detected local node already running.")
     except DockerException as ex:
         print(f"Failed to start local node: looks like your docker setup isn't right, please visit https://jenesis.fetch.ai/ for more information:\n\n{ex}")
     return None

--- a/src/jenesis/network/__init__.py
+++ b/src/jenesis/network/__init__.py
@@ -21,7 +21,9 @@ DEFAULT_GENESIS_ACCOUNT = "fetch1gns5lphdk5ew5lnre7ulzv8s8k9dr9eyqvgj0w"
 DEFAULT_DENOMINATION = "atestfet"
 DEFAULT_CLI_BINARY = "fetchd"
 
-TMP_DIR = tempfile.TemporaryDirectory() # pylint: disable=consider-using-with
+
+LOCALNODE_CONFIG_DIR = os.path.join(os.getcwd(), ".localnode")
+
 
 class Network(NetworkConfig):
 
@@ -35,6 +37,7 @@ class Network(NetworkConfig):
         url: str = "",
         faucet_url: Optional[str] = None,
         is_local: Optional[bool] = False,
+        keep_running: Optional[bool] = False,
         cli_binary: Optional[str] = None,
         validator_key_name: Optional[str] = None,
         mnemonic: Optional[str] = None,
@@ -54,6 +57,7 @@ class Network(NetworkConfig):
         self.name = name
         self.is_local = is_local
         if is_local:
+            self.keep_running = keep_running
             self.cli_binary = cli_binary or DEFAULT_CLI_BINARY
             self.validator_key_name = validator_key_name or DEFAULT_VALIDATOR_KEY_NAME
             self.mnemonic = mnemonic or DEFAULT_MNEMONIC
@@ -83,6 +87,8 @@ class LedgerNodeDockerContainer:
     def __init__(
         self,
         network: Network,
+        project_name: str,
+        profile_name: str,
         tag: str = DEFAULT_DOCKER_IMAGE_TAG,
     ):
         """
@@ -95,7 +101,14 @@ class LedgerNodeDockerContainer:
         """
         self._client = from_env()
         self._image_tag = tag
+        self._name = f"{network.name}-{project_name}-{profile_name}"
         self.network: Network = network
+
+        try:
+            self._client.containers.get(self._name)
+            self.container_exists = True
+        except Exception:
+            self.container_exists = False
 
     @property
     def tag(self) -> str:
@@ -107,6 +120,7 @@ class LedgerNodeDockerContainer:
         trace_flag = '--trace' if self.network.debug_trace else ''
         run_node_lines = [
             "#!/usr/bin/env bash",
+            'if [ ! -f /root/.fetchd/config/genesis.json ]; then',
             # variables
             f'export VALIDATOR_KEY_NAME={self.network.validator_key_name}',
             f'export VALIDATOR_MNEMONIC="{self.network.mnemonic}"',
@@ -131,25 +145,33 @@ class LedgerNodeDockerContainer:
             f'sed -i "s/stake/atestfet/" ~/.{self.network.cli_binary}/config/genesis.json',
             f'sed -i "s/enable = false/enable = true/" ~/.{self.network.cli_binary}/config/app.toml',
             f'sed -i "s/swagger = false/swagger = true/" ~/.{self.network.cli_binary}/config/app.toml',
+            'fi',
             f"{self.network.cli_binary} start --rpc.laddr tcp://0.0.0.0:26657 {trace_flag}",
         ])
         entrypoint_file = os.path.join(tmpdirname, "run-node.sh")
         with open(entrypoint_file, "w", encoding="utf-8") as file:
             file.writelines(line + "\n" for line in run_node_lines)
-        os.chmod(entrypoint_file, 300)
+        os.chmod(entrypoint_file, 333)
 
     def run(self):
-        self._make_entrypoint_file(TMP_DIR.name)
+        if not os.path.isdir(LOCALNODE_CONFIG_DIR):
+            os.mkdir(LOCALNODE_CONFIG_DIR)
+            self._make_entrypoint_file(LOCALNODE_CONFIG_DIR)
         mount_path = "/mnt"
-        volumes = {TMP_DIR.name: {"bind": mount_path, "mode": "rw"}}
+        volumes = {LOCALNODE_CONFIG_DIR: {"bind": mount_path, "mode": "rw"}}
         entrypoint = os.path.join(mount_path, "run-node.sh")
-        container = self._client.containers.run(
-            self.tag,
-            detach=True,
-            volumes=volumes,
-            entrypoint=str(entrypoint),
-            ports=self.PORTS,
-        )
+        try:
+            container: Container = self._client.containers.get(self._name)
+            container.start()
+        except Exception:
+            container = self._client.containers.run(
+                self.tag,
+                detach=True,
+                volumes=volumes,
+                entrypoint=str(entrypoint),
+                ports=self.PORTS,
+                name=self._name,
+            )
         return container
 
     @classmethod
@@ -172,35 +194,42 @@ class LedgerNodeDockerContainer:
         return False
 
 
-def run_local_node(network: Network) -> Optional[Container]:
+def run_local_node(network: Network, project_name: str, profile_name: str) -> Optional[Container]:
     try:
-        local_node = LedgerNodeDockerContainer(network)
-        if not local_node.is_ready():
+        local_node = LedgerNodeDockerContainer(network, project_name, profile_name)
+        if local_node.container_exists and local_node.is_ready():
+            print("Detected local node already running.")
+        else:
             print("Starting local node...")
             container = local_node.run()
-            if not container.status == "created":
+            container.reload()
+            if not container.status in {"created", "running"}:
                 raise RuntimeError('Failed to create local node.')
             if not local_node.wait_until_ready():
                 raise RuntimeError('Failed to start local node.')
             print("Stating local node...complete")
             return container
-        print("Detected local node already running.")
     except DockerException as ex:
-        print(f"Failed to start local node: looks like your docker setup isn't right, please visit https://jenesis.fetch.ai/ for more information:\n\n{ex}")
+        print(f"Failed to start local node: {ex}")
     return None
 
 
 @contextmanager
-def network_context(network: Network):
-    local_node = run_local_node(network)
+def network_context(network: Network, project_name: str, profile_name: str):
+    if network.is_local:
+        local_node = run_local_node(network, project_name, profile_name)
+    else:
+        local_node = None
     try:
         yield local_node
     finally:
         if local_node:
-            print("Shutting down local_node...")
-            local_node.kill()
-            local_node.remove()
-            print("Shutting down local_node...complete")
+            if network.keep_running:
+                print(f"Local node still running in background: {local_node.name}")
+            else:
+                print("Shutting down local_node...")
+                local_node.stop()
+                print("Shutting down local_node...complete")
 
 
 def fetchai_testnet_config() -> Network:

--- a/src/jenesis/network/__init__.py
+++ b/src/jenesis/network/__init__.py
@@ -1,7 +1,5 @@
 from contextlib import contextmanager
-from genericpath import isfile
 import os
-import tempfile
 import time
 import stat
 from typing import Optional, List
@@ -153,14 +151,14 @@ class LedgerNodeDockerContainer:
         return [line + "\n" for line in entrypoint_lines]
 
     def update_entrypoint_file(self) -> bool:
-        
+
         if not os.path.isdir(LOCALNODE_CONFIG_DIR):
             os.mkdir(LOCALNODE_CONFIG_DIR)
 
         previous_entrypoint_script = []
         entrypoint_file = os.path.join(LOCALNODE_CONFIG_DIR, "run-node.sh")
         if os.path.isfile(entrypoint_file):
-            with open(entrypoint_file) as file:
+            with open(entrypoint_file, encoding="utf-8") as file:
                 previous_entrypoint_script = file.readlines()
 
         entrypoint_script = self._make_entrypoint_script()

--- a/src/jenesis/tasks/__init__.py
+++ b/src/jenesis/tasks/__init__.py
@@ -53,3 +53,7 @@ class Task(ABC):
     @abstractmethod
     def poll(self):
         pass
+
+    @abstractmethod
+    def teardown(self):
+        pass

--- a/src/jenesis/tasks/container.py
+++ b/src/jenesis/tasks/container.py
@@ -66,14 +66,19 @@ class ContainerTask(Task):
             if exit_code == 0:
                 self._status = TaskStatus.COMPLETE
                 self._status_text = ''
-
-                # clean up the container if it was successful, otherwise keep if for the logs
-                self._container.remove()
             else:
                 self._status = TaskStatus.FAILED
                 self._status_text = ''
                 log_text = self._container.logs().decode("utf-8")
                 self._logs = log_text
+            self._container.remove()
+
+    def teardown(self):
+        if self._container and self._status == TaskStatus.IN_PROGRESS:
+            print(f'Stopping build container for {self.name}...')
+            self._container.kill()
+            print(f'Removing build container for {self.name}...')
+            self._container.remove()
 
     @abstractmethod
     def _is_out_of_date(self) -> bool:

--- a/src/jenesis/tasks/monitor.py
+++ b/src/jenesis/tasks/monitor.py
@@ -1,5 +1,6 @@
 import sys
 import time
+from docker.client import from_env
 from typing import List, Optional, Tuple, Dict
 
 from blessings import Terminal
@@ -101,38 +102,46 @@ def run_tasks(tasks: List[Task], poll_interval: Optional[float] = None) -> Tuple
     completed_tasks = []
     failed_tasks = []
 
-    while True:
+    try:
+        while True:
 
-        in_progress_tasks = []
+            in_progress_tasks = []
+            for task in tasks:
+
+                # query / process the task
+                task.poll()
+
+                # update the task
+                display.update(task)
+
+                # check the status of the task
+                if task.is_complete:
+                    completed_tasks.append(task)
+                elif task.is_failed:
+                    failed_tasks.append(task)
+                else:
+                    in_progress_tasks.append(task)
+
+            # update the display
+            display.render()
+
+            # update the task list
+            tasks = in_progress_tasks
+
+            # exit if all the tasks are now complete
+            if len(tasks) == 0:
+                break
+
+            time.sleep(poll_interval)
+
+        for task in failed_tasks + completed_tasks:
+            display.show_logs(task)
+
+    except KeyboardInterrupt:
+        print('\nKeyboardInterrupt: shutting down all tasks...')
         for task in tasks:
-
-            # query / process the task
-            task.poll()
-
-            # update the task
-            display.update(task)
-
-            # check the status of the task
-            if task.is_complete:
-                completed_tasks.append(task)
-            elif task.is_failed:
-                failed_tasks.append(task)
-            else:
-                in_progress_tasks.append(task)
-
-        # update the display
-        display.render()
-
-        # update the task list
-        tasks = in_progress_tasks
-
-        # exit if all the tasks are now complete
-        if len(tasks) == 0:
-            break
-
-        time.sleep(poll_interval)
-
-    for task in failed_tasks + completed_tasks:
-        display.show_logs(task)
+            task.teardown()
+        print('KeyboardInterrupt: shutting down all tasks...complete')
+        sys.exit(1)
 
     return completed_tasks, failed_tasks

--- a/src/jenesis/tasks/monitor.py
+++ b/src/jenesis/tasks/monitor.py
@@ -1,6 +1,5 @@
 import sys
 import time
-from docker.client import from_env
 from typing import List, Optional, Tuple, Dict
 
 from blessings import Terminal


### PR DESCRIPTION
- catches KeyboardInterrupt and tries to gracefully shutdown, stopping and removing build containers
- local node now runs in context manager and shuts down after script completes or shell exits unless configured `keep_running = true` in jenesis.toml.
- local nodes are named by `network_name-project_name-profile_name` and are started from where they left off from the appropriate project and profile if the containers are present