### PR TITLE
feat: automatically detect init contract addresses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,14 +28,6 @@ coverage = "^6.4.4"
 pytest = "^7.1.3"
 pylint = "^2.15.2"
 
-[tool.poetry.group.dev.dependencies]
-black = "^22.8.0"
-isort = "^5.10.1"
-mypy = "^0.971"
-flake8 = "^5.0.4"
-darglint = "^1.8.1"
-pylint = "^2.15.0"
-
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,14 @@ coverage = "^6.4.4"
 pytest = "^7.1.3"
 pylint = "^2.15.2"
 
+[tool.poetry.group.dev.dependencies]
+black = "^22.8.0"
+isort = "^5.10.1"
+mypy = "^0.971"
+flake8 = "^5.0.4"
+darglint = "^1.8.1"
+pylint = "^2.15.0"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/src/jenesis/config/__init__.py
+++ b/src/jenesis/config/__init__.py
@@ -31,7 +31,6 @@ class Deployment:
     deployer_key: str  # config: the name of the key to use for deployment
     init: Any  # config: init parameters for the contract
     init_funds: Optional[str] # config: funds to be sent with instantiation msg
-    init_addresses: Optional[list] # config: contract addresses needed in instantiation msg
     checksum: Optional[str]  # lock: the checksum digest to detect configuration changes
     digest: Optional[str]  # lock: the contract of the deployed contract
     address: Optional[Address]  # lock: the address of the deployed contract
@@ -240,7 +239,6 @@ class Config:
             init=extract_opt_dict(contract_cfg, "init"),
             deployer_key=extract_req_str(contract_cfg, "deployer_key"),
             init_funds=extract_opt_str(contract_cfg, "init_funds"),
-            init_addresses=extract_opt_list(contract_cfg, "init_addresses"),
             digest=extract_opt_str(lock, "digest"),
             address=opt_address(extract_opt_str(lock, "address")),
             code_id=extract_opt_int(lock, "code_id"),
@@ -273,7 +271,7 @@ class Config:
 
         deployments = {contract.name: Deployment(contract.name, contract.name,
             network_name, "", {arg: "" for arg in contract.init_args()},
-            "",[], None, None, None, None,
+            "", None, None, None, None,
         ) for contract in contracts}
 
         if network_name == "fetchai-testnet":
@@ -327,7 +325,7 @@ class Config:
 
         deployment = Deployment(deployment_name, contract.name,
             network_name, "", {arg: "" for arg in contract.init_args()},
-            "",[], None, None, None, None)
+            "", None, None, None, None)
 
         data = toml.load("jenesis.toml")
 
@@ -380,7 +378,6 @@ class Config:
                 "",
                 {arg: "" for arg in contract.init_args()},
                 "",
-                [],
                 None,
                 None,
                 None,

--- a/src/jenesis/contracts/deploy.py
+++ b/src/jenesis/contracts/deploy.py
@@ -32,7 +32,6 @@ def insert(data: Union[Dict, List], contract_name: str, address: str):
 def insert_address(contract_address_names: List[str], deployment: Deployment, profile: Profile) -> dict:
 
     deployment_names = list(profile.deployments.keys())
-
     init_data = deployment.init
 
     # iterate over the addresses to insert
@@ -214,7 +213,7 @@ def deploy_contracts(cfg: Config, project_path: str, deployer_key: Optional[str]
     deployments = profile.deployments
 
     init_addresses = {}
-    
+
     # iterate over the addresses to insert
     for (name, deployment) in deployments.items():
         init_data = deployment.init
@@ -233,10 +232,6 @@ def deploy_contracts(cfg: Config, project_path: str, deployer_key: Optional[str]
     # load all the keys required for this operation
     key_names = {deployment.deployer_key for deployment in deployments.values()} | {deployer_key}
     keys = load_keys(key_names)
-
-    print()
-    print("Deployment order: ", deployment_order)
-    print("----------------------------")
 
     for deployment_name in deployment_order:
         deployment = deployments[deployment_name]
@@ -277,12 +272,6 @@ def deploy_contracts(cfg: Config, project_path: str, deployer_key: Optional[str]
         contract_address_names = init_addresses[deployment_name]
 
         deployment.init = insert_address(contract_address_names, deployment, profile)
-
-        print()
-        print("--------------------------------")
-        print(deployment_name, " init msg:")
-        print(deployment.init)
-        print("--------------------------------")
 
         # lookup the wallet key
         wallet = LocalWallet(keys[deployment.deployer_key])

--- a/src/jenesis/contracts/deploy.py
+++ b/src/jenesis/contracts/deploy.py
@@ -23,7 +23,7 @@ from jenesis.tasks.monitor import run_tasks
 # Recursive function to insert deployed contract address into instantiation msg
 def insert(data: Union[Dict, List], contract_name: str, address: str):
     for key, value in data.items() if isinstance(data, dict) else enumerate(data):
-        if value == contract_name:
+        if value == ("$" + contract_name):
             data[key] = address
         elif isinstance(value, (dict, list)):
             insert(value, contract_name, address)
@@ -33,10 +33,11 @@ def insert_address(contract_address_names: List[str], deployment: Deployment, pr
 
     deployment_names = list(profile.deployments.keys())
 
+    init_data = deployment.init
+
     # iterate over the addresses to insert
     for name in contract_address_names:
         if name in deployment_names:
-            init_data = deployment.init
             deployed_contract_address = profile.deployments[name].address
 
             assert deployed_contract_address is not None, f"Contract {name} address not found"
@@ -46,6 +47,14 @@ def insert_address(contract_address_names: List[str], deployment: Deployment, pr
 
     return init_data
 
+def retreive_init_addresses(data: Union[Dict, List], contract_names: list, init_addresses: list):
+    for _, value in data.items() if isinstance(data, dict) else enumerate(data):
+        if isinstance(value, str) and value[0] == "$" and value[1:] in contract_names:
+            init_addresses.append(value[1:])
+            contract_names.remove(value[1:])
+        elif isinstance(value, (dict, list)):
+            retreive_init_addresses(value, contract_names,init_addresses)
+    return init_addresses
 
 def load_keys(key_names: Set[str]) -> Dict[str, PrivateKey]:
     keys = {}
@@ -204,17 +213,30 @@ def deploy_contracts(cfg: Config, project_path: str, deployer_key: Optional[str]
     project_contracts = {contract.name: contract for contract in detect_contracts(project_path)}
     deployments = profile.deployments
 
-    init_addresses = {
-        name: set(deployment.init_addresses)
-        for (name, deployment) in deployments.items()
-    }
+    init_addresses = {}
+    
+    # iterate over the addresses to insert
+    for (name, deployment) in deployments.items():
+        init_data = deployment.init
+        deployment_names = list(deployments.keys())
+
+        # retreive init addresses for each contract
+        contract_init_addresses = retreive_init_addresses(init_data, deployment_names, [])
+
+        # add all contract init addresses in one dictionary
+        init_addresses[name] = set(contract_init_addresses)
+
+    # sort the contracts to be deployed in the right order
+    sorter = gl.TopologicalSorter(init_addresses)
+    deployment_order = list(sorter.static_order())
 
     # load all the keys required for this operation
     key_names = {deployment.deployer_key for deployment in deployments.values()} | {deployer_key}
     keys = load_keys(key_names)
 
-    sorter = gl.TopologicalSorter(init_addresses)
-    deployment_order = list(sorter.static_order())
+    print()
+    print("Deployment order: ", deployment_order)
+    print("----------------------------")
 
     for deployment_name in deployment_order:
         deployment = deployments[deployment_name]
@@ -254,8 +276,13 @@ def deploy_contracts(cfg: Config, project_path: str, deployer_key: Optional[str]
 
         contract_address_names = init_addresses[deployment_name]
 
-        if len(contract_address_names) > 0:
-            deployment.init = insert_address(contract_address_names, deployment, profile)
+        deployment.init = insert_address(contract_address_names, deployment, profile)
+
+        print()
+        print("--------------------------------")
+        print(deployment_name, " init msg:")
+        print(deployment.init)
+        print("--------------------------------")
 
         # lookup the wallet key
         wallet = LocalWallet(keys[deployment.deployer_key])

--- a/src/jenesis/contracts/deploy.py
+++ b/src/jenesis/contracts/deploy.py
@@ -269,7 +269,7 @@ def deploy_contracts(cfg: Config, project_path: str, deployer_key: Optional[str]
 
         deployment.address = None  # clear the old address
 
-        contract_address_names = init_addresses[deployment_name]
+        contract_address_names = list(init_addresses[deployment_name])
 
         deployment.init = insert_address(contract_address_names, deployment, profile)
 

--- a/src/jenesis/contracts/deploy.py
+++ b/src/jenesis/contracts/deploy.py
@@ -46,7 +46,7 @@ def insert_address(contract_address_names: List[str], deployment: Deployment, pr
 
     return init_data
 
-def retreive_init_addresses(data: Union[Dict, List], contract_names: list, init_addresses: list):
+def retreive_init_addresses(data: Union[Dict, List], contract_names: List[str], init_addresses: List[str]):
     for _, value in data.items() if isinstance(data, dict) else enumerate(data):
         if isinstance(value, str) and value[0] == "$" and value[1:] in contract_names:
             init_addresses.append(value[1:])


### PR DESCRIPTION
If a certain contract needs other contract addresses for its instantiation msg you can simply write the $ symbol followed by the desired contract name in a string format. Example:

In this case, contract_1 needs contract_2 and contract_3 addresses

```
[profile.testing.contracts.contract_1.init]
count = 3
asset_decimals = [ 4, 4,]
asset_infos = [ {token =  { contract_addr = "$contract_2" }},{ native_token =  { contract_addr = "$contract_3"}}]
```
