### PR TITLE
feat: get custom msg types

### DIFF
--- a/src/jenesis/contracts/__init__.py
+++ b/src/jenesis/contracts/__init__.py
@@ -13,6 +13,18 @@ class Contract:
     cargo_root: str
     schema: dict
 
+    def __post_init__(self):
+        self.instantiate_schema = {}
+        self.query_schema = {}
+        self.execute_schema = {}
+        for (msg_type, schema) in self.schema.items():
+            if 'instantiate_msg' in msg_type:
+                self.instantiate_schema = schema
+            elif 'query_msg' in msg_type:
+                self.query_schema = schema
+            elif 'execute_msg' in msg_type:
+                self.execute_schema = schema
+
     def digest(self) -> Optional[str]:
         if not os.path.isfile(self.binary_path):
             return None
@@ -20,30 +32,29 @@ class Contract:
         return _compute_digest(self.binary_path).hex()
 
     def execute_msgs(self) -> dict:
-        return self._extract_msgs('execute_msg')
+        return self._extract_msgs(self.execute_schema)
 
     def query_msgs(self) -> dict:
-        return self._extract_msgs('query_msg')
+        return self._extract_msgs(self.query_schema)
 
     def init_args(self) -> dict:
-        return self.schema.get('instantiate_msg', {}).get('properties',{}).keys()
+        return list(self.instantiate_schema.get('properties',{}).keys())
 
-    def _extract_msgs(self, msg_type: str) -> dict:
+    def _extract_msgs(self, msg_schema: dict) -> dict:
         msgs = {}
-        if msg_type in self.schema:
-            if 'oneOf' in self.schema[msg_type]:
-                schemas = self.schema[msg_type]['oneOf']
-            elif 'anyOf' in self.schema[msg_type]:
-                schemas = self.schema[msg_type]['anyOf']
+        if 'oneOf' in msg_schema:
+            schemas = msg_schema['oneOf']
+        elif 'anyOf' in msg_schema:
+            schemas = msg_schema['anyOf']
+        else:
+            return msgs
+        for schema in schemas:
+            msg = schema['required'][0]
+            if 'required' in schema['properties'][msg]:
+                args = schema['properties'][msg]['required']
             else:
-                return msgs
-            for schema in schemas:
-                msg = schema['required'][0]
-                if 'required' in schema['properties'][msg]:
-                    args = schema['properties'][msg]['required']
-                else:
-                    args = []
-                msgs[msg] = args
+                args = []
+            msgs[msg] = args
         return msgs
 
     def __repr__(self):

--- a/src/jenesis/contracts/monkey.py
+++ b/src/jenesis/contracts/monkey.py
@@ -8,12 +8,9 @@ from cosmpy.aerial.tx_helpers import SubmittedTx
 from cosmpy.aerial.wallet import Wallet
 from cosmpy.crypto.address import Address
 from cosmpy.protos.cosmwasm.wasm.v1.query_pb2 import QueryCodeRequest
-from jsonschema import validate
+from jsonschema import ValidationError, validate as validate_schema
 from jenesis.contracts import Contract
 
-INSTANTIATE_MSG = "instantiate_msg"
-EXECUTE_MSG = "execute_msg"
-QUERY_MSG = "query_msg"
 
 class InstantiateArgsError(RuntimeError):
     pass
@@ -27,6 +24,14 @@ class ContractObserver(ABC):
     @abstractmethod
     def on_contract_address_update(self, address: Address):
         pass
+
+
+def validate(args: Any, schema: dict):
+    try:
+        validate_schema(args, schema)
+    except ValidationError as ex:
+        print("Contract message failed validation. To send to ledger anyway, retry with 'do_validate=False'")
+        raise ex
 
 
 class MonkeyContract(LedgerContract):
@@ -90,6 +95,7 @@ class MonkeyContract(LedgerContract):
             gas_limit: Optional[int] = None,
             admin_address: Optional[Address] = None,
             funds: Optional[str] = None,
+            do_validate: Optional[bool] = True,
     ) -> Address:
         # if no args provided, insert init args from configuration
         if args is None:
@@ -99,7 +105,8 @@ class MonkeyContract(LedgerContract):
                 raise InstantiateArgsError(
                     'Please provide instantiation arguments either in "args" or in the jenesis.toml configuration for this contract and profile'
                 )
-        validate(args, self._contract.schema[INSTANTIATE_MSG])
+        if do_validate and self._contract.instantiate_schema:
+            validate(args, self._contract.instantiate_schema)
         address = super().instantiate(code_id, args, sender, label=label, gas_limit=gas_limit,
                                       admin_address=admin_address, funds=funds)
 
@@ -117,6 +124,7 @@ class MonkeyContract(LedgerContract):
         instantiate_gas_limit: Optional[int] = None,
         admin_address: Optional[Address] = None,
         funds: Optional[str] = None,
+        do_validate: Optional[bool] = True,
     ) -> Address:
         code_id = self.store(sender, gas_limit=store_gas_limit)
         address = self.instantiate(
@@ -126,7 +134,8 @@ class MonkeyContract(LedgerContract):
             label=label,
             gas_limit=instantiate_gas_limit,
             admin_address=admin_address,
-            funds=funds
+            funds=funds,
+            do_validate=do_validate,
         )
         return address
 
@@ -136,12 +145,15 @@ class MonkeyContract(LedgerContract):
         sender: Wallet,
         gas_limit: Optional[int] = None,
         funds: Optional[str] = None,
+        do_validate: Optional[bool] = True,
     ) -> SubmittedTx:
-        validate(args, self._contract.schema[EXECUTE_MSG])
+        if do_validate and self._contract.execute_schema:
+            validate(args, self._contract.execute_schema)
         return super().execute(args, sender, gas_limit, funds)
 
-    def query(self, args: Any) -> Any:
-        validate(args, self._contract.schema[QUERY_MSG])
+    def query(self, args: Any, do_validate: Optional[bool] = True) -> Any:
+        if do_validate and self._contract.query_schema:
+            validate(args, self._contract.query_schema)
         return super().query(args)
 
     def _find_contract_id_by_digest_with_hint(self, code_id_hint: int) -> Optional[int]:


### PR DESCRIPTION
- Looks for `instantiate`, `query`, or `execute` in message type names to load schemas with custom names, as is used in some of the cw-plus contracts.
- Adds wrapper around validation call and allows user to force sending the msg even if validation fails with `do_validate=False`.