### PR TITLE
Add deployment

### DIFF
--- a/src/jenesis/cmd/add/__init__.py
+++ b/src/jenesis/cmd/add/__init__.py
@@ -3,6 +3,7 @@ import argparse
 from jenesis.cmd.add.contract import run_add_contract
 from jenesis.cmd.add.contract import add_contract_command
 from jenesis.cmd.add.profile import add_profile_command
+from jenesis.cmd.add.deployment import add_deployment_command
 
 
 def add_add_command(parser):
@@ -12,3 +13,4 @@ def add_add_command(parser):
 
     add_contract_command(subparsers)
     add_profile_command(subparsers)
+    add_deployment_command(subparsers)

--- a/src/jenesis/cmd/add/deployment.py
+++ b/src/jenesis/cmd/add/deployment.py
@@ -1,0 +1,43 @@
+import argparse
+import os
+import toml
+
+from jenesis.config import Config
+
+
+def run(args: argparse.Namespace):
+
+    project_root = os.path.abspath(os.getcwd())
+    contract_root = os.path.join(project_root, "contracts", args.contract)
+
+    # check that we are actually running the command from the project root
+    if not os.path.exists(os.path.join(project_root, "jenesis.toml")):
+        # pylint: disable=all
+        print("Please run command from project root")
+        return
+
+    # check if the contract exists
+    if not os.path.exists(contract_root):
+        print(f'Contract "{args.contract}" doesnt exist')
+        return
+
+    data = toml.load("jenesis.toml")
+
+    cfg = Config.load(project_root)
+    profiles = list(cfg.profiles.keys())
+
+    for profile in profiles:
+        data["profile"][profile]["contracts"][args.deployment] = data["profile"][profile]["contracts"][args.contract]
+        data["profile"][profile]["contracts"][args.deployment]["name"] = args.deployment
+    
+    project_configuration_file = os.path.join(project_root, "jenesis.toml")
+
+    with open(project_configuration_file, "w", encoding="utf-8") as toml_file:
+        toml.dump(data, toml_file)
+
+
+def add_deployment_command(parser):
+    deployment_cmd = parser.add_parser("deployment")
+    deployment_cmd.add_argument("contract", help="The name of the contract to duplicate")
+    deployment_cmd.add_argument("deployment", help="The name to assign the new deployment")
+    deployment_cmd.set_defaults(handler=run)


### PR DESCRIPTION
` jenesis add deployment <contract_name> <deployment_name>`.  automatically creates another contract_name entry called deployment_name. Allowing the user to create multiple deployments from one contract:
 
```
 [profile.testing.contracts.C]
name = "C"
contract = "C"
network = "fetchai-testnet"
deployer_key = "alice"
init_funds = ""

[profile.testing.contracts.C.init]
count = 1
```

Then you can run ` jenesis add deployment C C2`. and your jenesis.toml file will be updated to:

```
 [profile.testing.contracts.C]
name = "C"
contract = "C"
network = "fetchai-testnet"
deployer_key = "alice"
init_funds = ""

[profile.testing.contracts.C.init]
count = 1

 [profile.testing.contracts.C2]
name = "C2"
contract = "C"
network = "fetchai-testnet"
deployer_key = "alice"
init_funds = ""

[profile.testing.contracts.C2.init]
count = 1
```

Finally you can deploy using `jenesis deploy`

