### PR TITLE
feat: only look up code id the first time

### DIFF
--- a/src/jenesis/contracts/monkey.py
+++ b/src/jenesis/contracts/monkey.py
@@ -56,11 +56,21 @@ class MonkeyContract(LedgerContract):
         else:
             raise RuntimeError('Unable to determine contract digest')
 
-        # determine the code id
-        if code_id is not None:
+        # look up the code id if this is the first time
+        if code_id == 0:
+            self._code_id = 0
+        elif code_id is not None:
             self._code_id = self._find_contract_id_by_digest_with_hint(code_id)
         else:
             self._code_id = self._find_contract_id_by_digest(self._digest)
+
+        # if code id is not found, store this as code_id = 0 so we don't keep looking for it
+        if self._code_id is None:
+            self._code_id = 0
+
+        # trigger the observer if necessary
+        if self._observer is not None and self._code_id is not None:
+            self._observer.on_code_id_update(self._code_id)
 
         # add methods based on schema
         if contract.schema is not None:
@@ -118,6 +128,18 @@ class MonkeyContract(LedgerContract):
         admin_address: Optional[Address] = None,
         funds: Optional[str] = None,
     ) -> Address:
+
+        # in the case where the contract is already deployed
+        if self._address is not None and self._code_id is not None:
+            return self._address
+
+        assert self._address is None
+
+        if self._code_id is None or self._code_id == 0:
+            self.store(sender, gas_limit=store_gas_limit)
+
+        assert self._code_id
+
         code_id = self.store(sender, gas_limit=store_gas_limit)
         address = self.instantiate(
             code_id,


### PR DESCRIPTION
Running a script or starting the shell can take a long time on networks with a lot of deployed contracts because creating a `LedgerContract` triggers looking up the `code_id` from the digest. This PR assumes that if we don't find it the first time, it's highly unlikely that we will find it in later searches. By setting `code_id = 0` in this case, we can remember that the initial search failed and not try to look it up again. This considerably speeds up the contract creation step in projects with several contracts.